### PR TITLE
Prevent over-sizing of group heatmaps in nested columns

### DIFF
--- a/demo/nested_bug_pr133.html
+++ b/demo/nested_bug_pr133.html
@@ -33,6 +33,7 @@
       .column('a').column('b')
       .weightedSum('stack', 'a', 100, 'b', 100)
       .nested('multi canvas', 'a', 'as', 'bs', 'cs')
+      .groupBy('a');
 
     builder
       .ranking(ranking);

--- a/demo/nested_bug_pr133.html
+++ b/demo/nested_bug_pr133.html
@@ -38,6 +38,8 @@
     builder
       .ranking(ranking);
 
+    builder.aggregationStrategy('group')
+
 
     builder.buildTaggle(document.body);
   };

--- a/src/renderer/AAggregatedGroupRenderer.ts
+++ b/src/renderer/AAggregatedGroupRenderer.ts
@@ -19,11 +19,11 @@ export abstract class AAggregatedGroupRenderer<T extends Column> implements ICel
   createGroup(col: T, context: IRenderContext, imposer?: IImposer): IGroupCellRenderer {
     const single = this.create(col, context, imposer);
     return {
-      template: `<div>${single.template}</div>`,
+      template: single.template,
       update: (node: HTMLElement, group: IOrderedGroup) => {
         return context.tasks.groupRows(col, group, 'aagreated', (rows) => this.aggregatedIndex(rows, col)).then((data) => {
           if (typeof data !== 'symbol') {
-            single.update(<HTMLElement>node.firstElementChild!, data.row, data.index, group);
+            single.update(node, data.row, data.index, group);
           }
         });
       }

--- a/src/renderer/MultiLevelCellRenderer.ts
+++ b/src/renderer/MultiLevelCellRenderer.ts
@@ -41,9 +41,9 @@ export function createData(parent: {children: Column[]} & Column, context: IRend
     // inject data attributes
     template = template.replace(/^<([^ >]+)([ >])/, `<$1 data-column-id="${column.id}" data-renderer="${rendererId}"$2`);
     // inject classes
-    if (/^<([^ >]+)class="([ >])/.test(template)) {
+    if (/^<([^>]+) class="([ >]*)/.test(template)) {
       // has class attribute
-      template = template.replace(/^<([^ >]+)class="([ >])/, `<$1 class="${cssClass(`renderer-${rendererId}`)} $2`);
+      template = template.replace(/^<([^>]+) class="([ >]*)/, `<$1 class="${cssClass(`renderer-${rendererId}`)} $2`);
     } else {
       // inject as the others
       template = template.replace(/^<([^ >]+)([ >])/, `<$1 class="${cssClass(`renderer-${rendererId}`)}"$2`);
@@ -93,7 +93,7 @@ export default class MultiLevelCellRenderer extends AAggregatedGroupRenderer<IMu
         cols.forEach((col, ci) => {
           const weight = col.column.getWidth() / total;
           const cnode = children[ci];
-          cnode.classList.add(cssClass('stack-sub'), cssClass('detail'));
+          cnode.classList.add(cssClass(this.stacked ? 'stack-sub' : 'nested-sub'), cssClass('detail'));
           cnode.dataset.group = 'd';
           cnode.style.transform = stacked ? `translate(-${round((missingWeight / weight) * 100, 4)}%,0)` : null;
           cnode.style.gridColumnStart = (ci + 1).toString();
@@ -174,7 +174,7 @@ export default class MultiLevelCellRenderer extends AAggregatedGroupRenderer<IMu
         const children = <HTMLElement[]>Array.from(n.children);
         cols.forEach((col, ci) => {
           const cnode = children[ci];
-          cnode.classList.add(cssClass('stack-sub'), cssClass('group'));
+          cnode.classList.add(cssClass(this.stacked ? 'stack-sub' : 'nested-sub'), cssClass('group'));
           cnode.dataset.group = 'g';
           cnode.style.gridColumnStart = (ci + 1).toString();
           const r = col.groupRenderer!.update(cnode, group);

--- a/src/styles/renderer/_stack.scss
+++ b/src/styles/renderer/_stack.scss
@@ -3,5 +3,10 @@
 .#{$lu_css_prefix}-stack-sub {
   position: relative;
   height: 100%;
+}
+
+.#{$lu_css_prefix}-nested-sub {
+  position: relative;
+  height: 100%;
   width: calc(100% - #{$lu_engine_grip_gap}); // subtract gap to maintain grid
 }

--- a/src/styles/renderer/_stack.scss
+++ b/src/styles/renderer/_stack.scss
@@ -3,5 +3,5 @@
 .#{$lu_css_prefix}-stack-sub {
   position: relative;
   height: 100%;
-  width: calc(100% - $lu_engine_grip_gap); // subtract gap to maintain grid
+  width: calc(100% - #{$lu_engine_grip_gap}); // subtract gap to maintain grid
 }

--- a/src/styles/renderer/_stack.scss
+++ b/src/styles/renderer/_stack.scss
@@ -2,4 +2,5 @@
 
 .#{$lu_css_prefix}-stack-sub {
   height: 100%;
+  width: calc(100% - $lu_engine_grip_gap); // subtract gap to maintain grid
 }


### PR DESCRIPTION
closes Caleydo/lineup_app#46

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary

The over-sizing is caused by the increased row height for aggregated groups.

Reducing the row height to the standard `18px` will result in a normal heatmap width for nested columns.

![image](https://user-images.githubusercontent.com/5851088/52223859-e0a36e80-28a6-11e9-95e6-8e44a55c308c.png)

As soon as I increase the height the width of the nested heatmaps increases exceeds the column.

![image](https://user-images.githubusercontent.com/5851088/52223924-0892d200-28a7-11e9-9f39-b17005b64769.png)

By adding a `width:100%` the heatmaps stay within their column width.

![image](https://user-images.githubusercontent.com/5851088/52223964-26603700-28a7-11e9-8cbb-7e5cd5d8c33b.png)

However, now the gap between the nested columns disappeared. Hence, we must subtract the gap from the width to stay inline with the (nested column) grid.

![image](https://user-images.githubusercontent.com/5851088/52223993-3e37bb00-28a7-11e9-8843-7af63596fb68.png)

