### PR TITLE
Sgratzl/groupsort

### DIFF
--- a/demo/grouping.html
+++ b/demo/grouping.html
@@ -15,12 +15,13 @@
   window.onload = function () {
     const arr = [];
     const cats = ['c1', 'c2', 'c3'];
+    const cats2 = ['a1', 'a2'];
     for (let i = 0; i < 100; ++i) {
       arr.push({
         a: Math.random() * 10,
         d: 'Row ' + i,
         cat: cats[Math.floor(Math.random() * 3)],
-        cat2: cats[Math.floor(Math.random() * 3)]
+        cat2: cats2[Math.floor(Math.random() * 2)]
       })
     }
     const builder = LineUpJS.builder(arr);
@@ -30,9 +31,8 @@
       .supportTypes()
       .group()
       .allColumns() // add all columns
-      .groupBy('cat')
-      .sortBy('a', 'desc')
-      .sortBy('d', 'asc')
+      .groupBy('cat', 'cat2')
+      .groupSortBy('a')
 
     builder
       .ranking(ranking);

--- a/src/internal/math.ts
+++ b/src/internal/math.ts
@@ -1126,20 +1126,22 @@ function sortWorkerMain() {
  * to avoid webpack imports all the code functions need to be in this file
  * @internal
  */
-export const WORKER_BLOB = createWorkerCodeBlob([
-  pushAll.toString(),
-  quantile.toString(),
-  normalizedStatsBuilder.toString(),
-  boxplotBuilder.toString(),
-  computeGranularity.toString(),
-  pushDateHist.toString(),
-  dateStatsBuilder.toString(),
-  categoricalStatsBuilder.toString(),
-  createIndexArray.toString(),
-  asc.toString(),
-  desc.toString(),
-  sortComplex.toString(),
-  dateValueCache2Value.toString(),
-  categoricalValueCache2Value.toString(),
-  toFunctionBody(sortWorkerMain)
-]);
+export function createWorkerBlob() {
+  return createWorkerCodeBlob([
+    pushAll.toString(),
+    quantile.toString(),
+    normalizedStatsBuilder.toString(),
+    boxplotBuilder.toString(),
+    computeGranularity.toString(),
+    pushDateHist.toString(),
+    dateStatsBuilder.toString(),
+    categoricalStatsBuilder.toString(),
+    createIndexArray.toString(),
+    asc.toString(),
+    desc.toString(),
+    sortComplex.toString(),
+    dateValueCache2Value.toString(),
+    categoricalValueCache2Value.toString(),
+    toFunctionBody(sortWorkerMain)
+  ]);
+}

--- a/src/model/BooleanColumn.ts
+++ b/src/model/BooleanColumn.ts
@@ -228,6 +228,6 @@ export default class BooleanColumn extends ValueColumn<boolean> implements ICate
 
   group(row: IDataRow) {
     const enabled = this.getValue(row);
-    return enabled ? BooleanColumn.GROUP_TRUE : BooleanColumn.GROUP_FALSE;
+    return Object.assign({}, enabled ? BooleanColumn.GROUP_TRUE : BooleanColumn.GROUP_FALSE);
   }
 }

--- a/src/model/CategoricalColumn.ts
+++ b/src/model/CategoricalColumn.ts
@@ -215,7 +215,7 @@ export default class CategoricalColumn extends ValueColumn<string> implements IC
   group(row: IDataRow, valueCache?: any): IGroup {
     const cat = valueCache !== undefined ? valueCache : this.getCategory(row);
     if (!cat) {
-      return missingGroup;
+      return Object.assign({}, missingGroup);
     }
     return {name: cat.label, color: cat.color};
   }

--- a/src/model/Column.ts
+++ b/src/model/Column.ts
@@ -500,7 +500,7 @@ export default class Column extends AEventDispatcher {
    * @return {IGroup}
    */
   group(_row: IDataRow, _valueCache?: any): IGroup {
-    return defaultGroup;
+    return Object.assign({}, defaultGroup);
   }
 
   toCompareGroupValue(_rows: ISequence<IDataRow>, group: IGroup, _valueCache?: ISequence<any>): ICompareValue | ICompareValue[] {

--- a/src/model/DateColumn.ts
+++ b/src/model/DateColumn.ts
@@ -182,10 +182,10 @@ export default class DateColumn extends ValueColumn<Date> implements IDateColumn
   group(row: IDataRow, valueCache?: any): IGroup {
     const v = valueCache !== undefined ? valueCache : this.getDate(row);
     if (!v || !(v instanceof Date)) {
-      return missingGroup;
+      return Object.assign({}, missingGroup);
     }
     if (!this.currentGrouper) {
-      return defaultGroup;
+      return Object.assign({}, defaultGroup);
     }
     const g = toDateGroup(this.currentGrouper, v);
     return {

--- a/src/model/HierarchyColumn.ts
+++ b/src/model/HierarchyColumn.ts
@@ -292,7 +292,7 @@ export default class HierarchyColumn extends ValueColumn<string> implements ICat
   group(row: IDataRow): IGroup {
     const base = this.getCategory(row);
     if (!base) {
-      return missingGroup;
+      return Object.assign({}, missingGroup);
     }
     return {name: base.label, color: base.color};
   }

--- a/src/model/NumberColumn.ts
+++ b/src/model/NumberColumn.ts
@@ -323,7 +323,7 @@ export default class NumberColumn extends ValueColumn<number> implements INumber
   group(row: IDataRow): IGroup {
     const value = this.getRawNumber(row);
     if (isNaN(value)) {
-      return missingGroup;
+      return Object.assign({}, missingGroup);
     }
 
     let threshold = this.currentGroupThresholds;

--- a/src/model/SelectionColumn.ts
+++ b/src/model/SelectionColumn.ts
@@ -128,6 +128,6 @@ export default class SelectionColumn extends ValueColumn<boolean> {
 
   group(row: IDataRow) {
     const isSelected = this.getValue(row);
-    return isSelected ? SelectionColumn.SELECTED_GROUP : SelectionColumn.NOT_SELECTED_GROUP;
+    return Object.assign({}, isSelected ? SelectionColumn.SELECTED_GROUP : SelectionColumn.NOT_SELECTED_GROUP);
   }
 }

--- a/src/model/StringColumn.ts
+++ b/src/model/StringColumn.ts
@@ -184,16 +184,16 @@ export default class StringColumn extends ValueColumn<string> {
 
   group(row: IDataRow): IGroup {
     if (this.getValue(row) == null) {
-      return missingGroup;
+      return Object.assign({}, missingGroup);
     }
 
     if (this.currentGroupCriteria.length === 0) {
-      return othersGroup;
+      return Object.assign({}, othersGroup);
     }
     const value = this.getLabel(row);
 
     if (!value) {
-      return missingGroup;
+      return Object.assign({}, missingGroup);
     }
 
     for (const criteria of this.currentGroupCriteria) {
@@ -205,7 +205,7 @@ export default class StringColumn extends ValueColumn<string> {
         color: defaultGroup.color
       };
     }
-    return othersGroup;
+    return Object.assign({}, othersGroup);
   }
 
 

--- a/src/model/internal.ts
+++ b/src/model/internal.ts
@@ -1,6 +1,6 @@
 import {schemeCategory10, schemeSet3} from 'd3-scale-chromatic';
 import Column, {defaultGroup, IGroup, IGroupParent, IndicesArray, IOrderedGroup, ECompareValueType} from '.';
-import {OrderedSet} from '../internal';
+import {OrderedSet, max} from '../internal';
 import {DEFAULT_COLOR} from './interfaces';
 
 
@@ -50,37 +50,68 @@ export function toGroupID(group: IGroup) {
 }
 
 /** @internal */
+export function isOrderedGroup(g: IOrderedGroup | Readonly<IGroupParent>): g is IOrderedGroup {
+  return (<IOrderedGroup>g).order != null;
+}
+
+
+/** @internal */
+function isGroupParent(g: IOrderedGroup | Readonly<IGroupParent>): g is IGroupParent {
+  return (<IGroupParent>g).subGroups != null;
+}
+
+/**
+ * unify the parents of the given groups by reusing the same group parent if possible
+ * @param groups
+ */
 export function unifyParents<T extends IOrderedGroup>(groups: T[]) {
   if (groups.length <= 1) {
-    return;
+    return groups;
   }
-  const lookup = new Map<string, IGroupParent>();
 
-  const resolve = (g: IGroupParent): {g: IGroupParent, id: string} => {
-    let id = g.name;
-    if (g.parent) {
-      const parent = resolve(g.parent);
-      g.parent = parent.g;
-      id = `${parent.id}.${id}`;
+  const toPath = (group: T) => {
+    const path: (IGroupParent | T)[] = [group];
+    let p = group.parent;
+    while (p) {
+      path.unshift(p);
+      p = p.parent;
     }
-    // ensure there is only one instance per id (i.e. share common parents
-    if (lookup.has(id)) {
-      return {g: lookup.get(id)!, id};
-    }
-    if (g.parent) {
-      g.parent.subGroups.push(g);
-    }
-    g.subGroups = []; // clear old children
-    lookup.set(id, g);
-    return {g, id};
+    return path;
   };
-  // resolve just parents
-  groups.forEach((g) => {
-    if (g.parent) {
-      g.parent = resolve(g.parent).g;
-      g.parent.subGroups.push(g);
+
+  const paths = groups.map(toPath);
+  // now unify paths
+  const maxLevel = max(paths.map((d) => d.length));
+  for (let level = 0; level < maxLevel; ++level) {
+    let currentParent: IGroupParent | null = null;
+    for (const path of paths) {
+      const node = path[level];
+      // null reset
+      if (!node || !isGroupParent(node)) {
+        currentParent = null;
+        continue;
+      }
+      // first time seeing this parent
+      if (!currentParent || currentParent.parent !== node.parent || currentParent.name !== node.name) {
+        currentParent = node;
+        const firstChild = path[level + 1];
+        // reset parent
+        if (firstChild) {
+          node.subGroups = [firstChild];
+        } else {
+          node.subGroups = [];
+        }
+        continue;
+      }
+      // same parent, reuse instance
+      const nextChild = path[level + 1];
+      if (nextChild) {
+        currentParent.subGroups.push(nextChild);
+        nextChild.parent = currentParent;
+      }
     }
-  });
+  }
+  return groups;
 }
 
 /** @internal */
@@ -96,10 +127,6 @@ export function groupRoots(groups: IOrderedGroup[]) {
   return Array.from(roots);
 }
 
-/** @internal */
-export function isOrderedGroup(g: IOrderedGroup | Readonly<IGroupParent>): g is IOrderedGroup {
-  return (<IOrderedGroup>g).order != null;
-}
 
 // based on https://github.com/d3/d3-scale-chromatic#d3-scale-chromatic
 const colors = schemeCategory10.concat(schemeSet3);

--- a/src/model/internal.ts
+++ b/src/model/internal.ts
@@ -93,13 +93,14 @@ export function unifyParents<T extends IOrderedGroup>(groups: T[]) {
       }
       // first time seeing this parent
       if (!currentParent || currentParent.parent !== node.parent || currentParent.name !== node.name) {
-        currentParent = node;
+        currentParent = Object.assign({}, node); // copy
         const firstChild = path[level + 1];
         // reset parent
         if (firstChild) {
-          node.subGroups = [firstChild];
+          currentParent.subGroups = [firstChild];
+          firstChild.parent = currentParent;
         } else {
-          node.subGroups = [];
+          currentParent.subGroups = [];
         }
         continue;
       }

--- a/src/provider/ADataProvider.ts
+++ b/src/provider/ADataProvider.ts
@@ -350,7 +350,7 @@ abstract class ADataProvider extends AEventDispatcher implements IDataProvider {
     this.fireBusy(true);
     const reason = dirtyReason || [EDirtyReason.UNKNOWN];
     Promise.resolve(this.sort(ranking, reason)).then(({groups, index2pos}) => {
-      unifyParents(groups);
+      groups = unifyParents(groups);
       this.initAggregateState(ranking, groups);
       ranking.setGroups(groups, index2pos, reason);
       this.fireBusy(false);

--- a/src/provider/LocalDataProvider.ts
+++ b/src/provider/LocalDataProvider.ts
@@ -386,9 +386,9 @@ export default class LocalDataProvider extends ACommonDataProvider {
     if (groupLookup) {
       const groupIndices = groups.map((_, i) => i);
       sortComplex(groupIndices, groupLookup.sortOrders);
-      groups = groupIndices.map((i) => groups[i]);
+      return groupIndices.map((i) => groups[i]);
     }
-    return groups;
+    return groups.sort((a, b) => a.name.localeCompare(b.name));
   }
 
   private index2pos(groups: IOrderedGroup[], maxDataIndex: number) {

--- a/src/provider/ScheduledTasks.ts
+++ b/src/provider/ScheduledTasks.ts
@@ -1,5 +1,5 @@
 import {abortAble} from 'lineupengine';
-import {getNumberOfBins, IAdvancedBoxPlotData, ICategoricalStatistics, IDateStatistics, ISequence, ISortMessageResponse, IStatistics, lazySeq, toIndexArray, WorkerTaskScheduler, WORKER_BLOB} from '../internal';
+import {getNumberOfBins, IAdvancedBoxPlotData, ICategoricalStatistics, IDateStatistics, ISequence, ISortMessageResponse, IStatistics, lazySeq, toIndexArray, WorkerTaskScheduler, createWorkerBlob} from '../internal';
 import TaskScheduler, {ABORTED, oneShotIterator} from '../internal/scheduler';
 import Column, {ICategoricalLikeColumn, ICompareValue, IDataRow, IDateColumn, IGroup, IndicesArray, INumberColumn, IOrderedGroup, isCategoricalLikeColumn, isDateColumn, isNumberColumn, Ranking, UIntTypedArray} from '../model';
 import {IRenderTask} from '../renderer';
@@ -11,7 +11,7 @@ export class ScheduleRenderTasks extends ARenderTasks implements IRenderTaskExec
 
   private readonly cache = new Map<string, IRenderTask<any>>();
   private readonly tasks = new TaskScheduler();
-  private readonly workers = new WorkerTaskScheduler(WORKER_BLOB);
+  private readonly workers = new WorkerTaskScheduler(createWorkerBlob());
 
   setData(data: IDataRow[]) {
     this.data = data;

--- a/src/renderer/GroupCellRenderer.ts
+++ b/src/renderer/GroupCellRenderer.ts
@@ -1,6 +1,11 @@
-import {Column, GroupColumn, IOrderedGroup} from '../model';
+import {Column, GroupColumn, IOrderedGroup, IGroup, defaultGroup, IDataRow} from '../model';
 import {ICellRendererFactory} from './interfaces';
 import {noRenderer} from './utils';
+
+
+function isDummyGroup(group: IGroup) {
+  return group.parent == null && group.name === defaultGroup.name;
+}
 
 /** @internal */
 export default class GroupCellRenderer implements ICellRendererFactory {
@@ -11,14 +16,22 @@ export default class GroupCellRenderer implements ICellRendererFactory {
   }
 
   create() {
-    return noRenderer;
+    return {
+      template: `<div><div></div></div>`,
+      update(node: HTMLElement, _row: IDataRow, i: number, group: IOrderedGroup) {
+        (<HTMLElement>node.firstElementChild!).textContent = isDummyGroup(group) || i > 0 ? '' : `${group.name} (${group.order.length})`;
+      },
+      render(_ctx: CanvasRenderingContext2D, _row: IDataRow, i: number) {
+        return i === 0;
+      }
+    };
   }
 
   createGroup() {
     return {
       template: `<div><div></div></div>`,
       update(node: HTMLElement, group: IOrderedGroup) {
-        (<HTMLElement>node.firstElementChild!).textContent = `${group.name} (${group.order.length})`;
+        (<HTMLElement>node.firstElementChild!).textContent = isDummyGroup(group) ? '' : `${group.name} (${group.order.length})`;
       }
     };
   }

--- a/src/styles/renderer/_aggregate.scss
+++ b/src/styles/renderer/_aggregate.scss
@@ -9,6 +9,12 @@
   }
 }
 
+.#{$lu_css_prefix}-renderer-group {
+  &.#{$engine_css_prefix}-td {
+    overflow: visible;
+  }
+}
+
 .#{$lu_css_prefix}-agg-level {
   flex: 0 0 $lu_aggregate_level_width;
   position: relative; // square bracket around

--- a/tests/model/internal.spec.ts
+++ b/tests/model/internal.spec.ts
@@ -1,0 +1,86 @@
+import {unifyParents} from '../../src/model/internal';
+import {IGroupParent, IOrderedGroup} from '../../src/model';
+
+function groupGen(name: string, parent?: IGroupParent): IOrderedGroup {
+  return {
+    color: 'gray',
+    name,
+    order: [],
+    parent
+  };
+}
+
+function parentGen(name: string, parent?: IGroupParent): IGroupParent {
+  return {
+    name,
+    color: 'gray',
+    parent,
+    subGroups: []
+  };
+}
+
+describe('unifyParents', () => {
+  it('[]', () => {
+    expect(unifyParents([])).toEqual([]);
+  });
+  it('single', () => {
+    const a = groupGen('a');
+    expect(unifyParents([a])).toEqual([a]);
+  });
+  it('different', () => {
+    const a = groupGen('a');
+    const b = groupGen('b');
+    expect(unifyParents([a, b])).toEqual([a, b]);
+  });
+  it('common parent', () => {
+    const p = parentGen('p');
+    const pClone = parentGen('p');
+    const a = groupGen('a', p);
+    const b = groupGen('b', pClone);
+    unifyParents([a, b]);
+    expect(a.parent).toBe(p);
+    expect(a.parent).toBe(b.parent);
+  });
+  it('different parent', () => {
+    const p = parentGen('p');
+    const p2 = parentGen('p2');
+    const a = groupGen('a', p);
+    const b = groupGen('b', p2);
+    unifyParents([a, b]);
+    expect(a.parent).toBe(p);
+    expect(a.parent).not.toBe(b.parent);
+  });
+  it('different in the middle', () => {
+    const p = parentGen('p');
+    const pClone = parentGen('p');
+    const p2 = parentGen('p2');
+    const a = groupGen('a', p);
+    const b = groupGen('b', p2);
+    const c = groupGen('c', pClone); // same as p
+    unifyParents([a, b, c]);
+    expect(a.parent).toBe(p);
+    expect(b.parent).toBe(p2);
+    expect(c.parent).toBe(pClone);
+    expect(a.parent).not.toBe(c.parent);
+  });
+
+  it('same - different - separate', () => {
+    const r = parentGen('r');
+    const rClone = parentGen('r');
+    const rClone2 = parentGen('r');
+
+    const p = parentGen('p', r);
+    const pClone = parentGen('p', rClone);
+    const p2 = parentGen('p2', rClone2);
+    const a = groupGen('a', p);
+    const b = groupGen('b', p2);
+    const c = groupGen('c', pClone);
+    unifyParents([a, b, c]);
+    expect(a.parent).toBe(p);
+    expect(b.parent).toBe(p2);
+    expect(c.parent).toBe(pClone);
+    expect(p.parent).toBe(r);
+    expect(pClone.parent).toBe(r);
+    expect(p2.parent).toBe(r);
+  });
+});

--- a/tests/model/internal.spec.ts
+++ b/tests/model/internal.spec.ts
@@ -38,7 +38,6 @@ describe('unifyParents', () => {
     const a = groupGen('a', p);
     const b = groupGen('b', pClone);
     unifyParents([a, b]);
-    expect(a.parent).toBe(p);
     expect(a.parent).toBe(b.parent);
   });
   it('different parent', () => {
@@ -47,7 +46,6 @@ describe('unifyParents', () => {
     const a = groupGen('a', p);
     const b = groupGen('b', p2);
     unifyParents([a, b]);
-    expect(a.parent).toBe(p);
     expect(a.parent).not.toBe(b.parent);
   });
   it('different in the middle', () => {
@@ -58,10 +56,9 @@ describe('unifyParents', () => {
     const b = groupGen('b', p2);
     const c = groupGen('c', pClone); // same as p
     unifyParents([a, b, c]);
-    expect(a.parent).toBe(p);
-    expect(b.parent).toBe(p2);
-    expect(c.parent).toBe(pClone);
+    expect(a.parent).not.toBe(b.parent);
     expect(a.parent).not.toBe(c.parent);
+    expect(b.parent).not.toBe(c.parent);
   });
 
   it('same - different - separate', () => {
@@ -76,11 +73,11 @@ describe('unifyParents', () => {
     const b = groupGen('b', p2);
     const c = groupGen('c', pClone);
     unifyParents([a, b, c]);
-    expect(a.parent).toBe(p);
-    expect(b.parent).toBe(p2);
-    expect(c.parent).toBe(pClone);
-    expect(p.parent).toBe(r);
-    expect(pClone.parent).toBe(r);
-    expect(p2.parent).toBe(r);
+    expect(a.parent!.parent).toBe(b.parent!.parent);
+    expect(a.parent!.parent).toBe(c.parent!.parent);
+
+    expect(a.parent).not.toBe(b.parent);
+    expect(a.parent).not.toBe(c.parent);
+    expect(b.parent).not.toBe(c.parent);
   });
 });


### PR DESCRIPTION
closes #141

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [ ] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
 
fixes the group sorting issues

without sorting and two levels:

![2019-03-13 16_17_44-LineUp Builder Test](https://user-images.githubusercontent.com/4129778/54290693-b6cb1f00-45ab-11e9-9e81-1822be3f095b.png)

group sorted by A:

![2019-03-13 16_16_47-Window](https://user-images.githubusercontent.com/4129778/54290705-b9c60f80-45ab-11e9-9998-f4df707c2d65.png)
