### PR TITLE
work on safari translate3d issues

### DIFF
--- a/src/styles/_lineup.scss
+++ b/src/styles/_lineup.scss
@@ -12,6 +12,7 @@
 @import './datatypes';
 @import './taggle/index';
 @import './supported_browser';
+@import './safari';
 
 .#{$lu_css_prefix} {
   position: relative;

--- a/src/styles/_safari.scss
+++ b/src/styles/_safari.scss
@@ -1,0 +1,15 @@
+// safari 10+ only
+// see https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari-only-not-chrome#25975282
+
+@import './vars';
+
+$lu_safari_check: 0.001dpcm;
+
+@media not all and (min-resolution: $lu_safari_check) {
+  @supports (-webkit-appearance: none) {
+    .#{$engine_css_prefix}-header,
+    .#{$lu_css_prefix}-side-panel {
+      transform: unset;
+    }
+  }
+}

--- a/src/ui/dialogs/DialogManager.ts
+++ b/src/ui/dialogs/DialogManager.ts
@@ -25,7 +25,8 @@ export default class DialogManager {
   setHighlight(mask: { left: number, top: number, width: number, height: number }) {
     const area = <HTMLElement>this.node.firstElementChild;
     // @see http://bennettfeely.com/clippy/ -> select `Frame` example
-    area.style.clipPath = `polygon(
+    // use webkit prefix for safari
+    area.style.clipPath = (<any>area.style).webkitClipPath = `polygon(
       0% 0%,
       0% 100%,
       ${mask.left}px 100%,


### PR DESCRIPTION
closes #143 

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [ ] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
 
uses Safari CSS hacks to remove the translate3d from header and side panel, since it confuses Safari + use prefix clip path for proper backdrop support


![image](https://user-images.githubusercontent.com/4129778/56105925-0a050880-5f82-11e9-83d0-f8a3796a0ea3.png)

