### PR TITLE
Generate `types:27` on `npm run prepack`

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "postdist": "npm run docs && cross-zip ./build/docs ../dist/lineupjs_docs.zip",
     "preversion": "npm test",
     "prepare": "echo 'dummy prepare since prepack has no dev dependencies'",
-    "prepack": "npm run clean && npm run compile && npm run build:prod",
+    "prepack": "npm run clean && npm run compile && npm run build:prod && npm run types:27",
     "release:major": "release-it major",
     "release:minor": "release-it minor",
     "release:patch": "release-it patch",


### PR DESCRIPTION
**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary

`npm run prepack` is used if lineupjs is added as git dependency (e.g., in the lineup_app). With the most recent changes, the lineup_app will not compile, due to missing .d.ts files. Generating the typings when installing lineupjs as dependency fixes the problem.
