### PR TITLE
Improving compatibility with bootstrap styles

### DIFF
--- a/src/styles/_lineup.scss
+++ b/src/styles/_lineup.scss
@@ -16,6 +16,7 @@
 
 .#{$lu_css_prefix} {
   position: relative;
+  line-height: normal;
 
   > aside {
     float: right;


### PR DESCRIPTION

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [ ] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
Bootstrap style sheets (tested v3.3.7 and v4.3.1) set the line-height declaration in the body selector to a value higher than the default. This causes rows in LineUp to overflow and trigger many unnecessary scroll events that slow down vertical scrolling. Setting the line-height to the default value in LineUp fixes this issue.
