### PR TITLE
 Allow `color` property in column description but show deprecated warning

### DIFF
--- a/src/model/ColorMappingFunction.ts
+++ b/src/model/ColorMappingFunction.ts
@@ -279,6 +279,10 @@ export function createColorMappingFunction(dump: any): IColorMappingFunction {
  * @internal
  */
 export function restoreColorMapping(desc: IMapAbleDesc): IColorMappingFunction {
+  if(desc.color) {
+    console.warn('The property `color` in the column description is deprecated and will not work in an upcoming LineUp release. Use the property `colorMapping` instead.');
+    return createColorMappingFunction(desc.color);
+  }
   if (desc.colorMapping) {
     return createColorMappingFunction(desc.colorMapping);
   }


### PR DESCRIPTION
Closes #174

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary

*  Allow `color` property in column description but show deprecated warning to mantain backward compatibility