### PR TITLE
Fix reset of filter for missing values

### DIFF
--- a/src/ui/missing.ts
+++ b/src/ui/missing.ts
@@ -22,11 +22,7 @@ export function findFilterMissing(node: HTMLElement) {
 /** @internal */
 export function updateFilterMissingNumberMarkup(element: HTMLElement, count: number) {
   const checked = element.querySelector('input')!;
-  if (count > 0) {
-    element.classList.remove('lu-disabled');
-    checked.disabled = false;
-  }
-  if (!checked.checked) {
-    element.lastElementChild!.textContent = `Filter ${count} remaining missing value rows`;
-  }
+  checked.disabled = (count === 0 && !checked.checked); // disable checkbox only if there are no missing values and the checkbox is unchecked (i.e., assumes that the checkbox is unchecked at the beginning)
+  element.lastElementChild!.classList.toggle('lu-disabled', checked.disabled);
+  element.lastElementChild!.textContent = `Filter ${count} missing value rows`;
 }


### PR DESCRIPTION
closes #101 

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary

A simple backport of the v4 code is not possible, because the whole stat calcuation has been refactored and uses scheduler and tasks.

This PR fixes it in a way that the checkbox is always enabled if the checkbox is checked. 

![lineup-fix-missing-values-filter](https://user-images.githubusercontent.com/5851088/64784725-0a262600-d56b-11e9-91c1-4c5ff219a03e.gif)

### Not fixed

The number of rows is set to 0 when the filter is active. In my opinion the number of rows with missing values should remain the same, indepdent of the filter status. 

I digged into the problem and found out that the missing values are checked/counted for currently visible rows.

Example: A ranking with 100 rows and 10 missing values for one column. Filtering the missing values shows the remaining 90 rows. Now the count of missing values is 0, which is correct, but at the same time it disables the checkbox. Hence, two missing values would be required:

1. number of total rows with missing values (independent of already filtered rows)
2. number of missing values of the visible rows

In the example the first value would be always 10 rows, but the second value would update according to the currently visible rows.

The histogram is calculated in _EngineRenderer.updateHist()_

https://github.com/lineupjs/lineupjs/blob/23ca83caefc3200156d4a3af5d1f14c59db76657/src/ui/EngineRenderer.ts#L228-L253

The problem occurs that `ranking.getOrder()` returns the visible rows only and I could not find a function that returns the all available rows (indepdent of the filter/visibility). 

@sgratzl Is there away to solve this problem in LineUp v3?