### PR TITLE
Fix number filter by comparing the min / max values to the domai…

### DIFF
--- a/demo/small_numbers.html
+++ b/demo/small_numbers.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Document</title>
+    <link href="./LineUpJS.css" rel="stylesheet">
+
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      .lu {
+        clear: both;
+        position: absolute;
+        top: 1px;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <script src="./LineUpJS.js"></script>
+    <script>
+    const testData = [
+        { n: 0.000054921, m: 1.234 },
+        { n: 0.0000417014, m: 2.342342523 },
+        { n: 1.265e-7, m: 12.312412 },
+        { n: 0.0000417014, m: 5.243325 },
+        { n: 7.8e-9, m: 9.32524 },
+        { n: 0.0000417014, m: 5.45472523 },
+        { n: 0.0000526039, m: 6.42345323 },
+        { n: 0.0000417014, m: 7.332523 },
+        { n: 5.14e-8, m: 6.4234532523 },
+        { n: 0.0000156167, m: 3.42334242523 },
+        { n: 0.0000035539, m: 6.423523 },
+        { n: 0.0000417014, m: 1.523 },
+        { n: 2.722e-7, m: 6.4234532523 },
+        { n: 0.0000146095, m: 8.532523 },
+        { n: 0.0000040818, m: 1.42523 },
+        { n: 0.0000247558, m: 8.32523 },
+        { n: 0.0000313286, m: 2.321441533 },
+        { n: 0.0000417014, m: 6.43 },
+        { n: 0.0000013006, m: 6.3 },
+        { n: 0.0000417014, m: 8.53 },
+        { n: 0.0000012201, m: 6 },
+        { n: 0.0000417014, m: 1.3 },
+        { n: 0.0000050403, m: 6.4234532523 },
+        { n: 0.0000417014, m: 10.44453 },
+        { n: 0.0000021525, m: 9.3 },
+        { n: 0.0000036857, m: 6.4234532523 },
+        { n: 1.16e-8, m: 6.4234532523 },
+        { n: 0.0000153442, m: 6.4234532523 },
+      ];
+
+      const minN = Math.min(...testData.map(d => d.n));
+      const maxN = Math.max(...testData.map(d => d.n));
+
+      const builder = LineUpJS.builder(testData);
+
+      builder.column(
+        LineUpJS.buildNumberColumn('n')
+          .label('Column with small numbers')
+          .width(250)
+          .mapping('log', [minN, maxN], [1, 0])
+          .custom('numberFormat', 'e'),
+      );
+
+
+      const minM = Math.min(...testData.map(d => d.m));
+      const maxM = Math.max(...testData.map(d => d.m));
+
+      builder.column(
+        LineUpJS.buildNumberColumn('m')
+          .label('Column with numbers > 1')
+          .width(250)
+          .mapping('log', [minM, maxM], [1, 0])
+      );
+
+      builder.build(document.body);
+    </script>
+  </body>
+</html>

--- a/src/renderer/HistogramCellRenderer.ts
+++ b/src/renderer/HistogramCellRenderer.ts
@@ -156,8 +156,8 @@ function createFilterContext(col: IMapAbleColumn, context: IRenderContext): IFil
     format: (v) => round(v, 2).toString(),
     setFilter: (filterMissing, minValue, maxValue) => col.setFilter({
       filterMissing,
-      min: Math.abs(minValue - domain[0]) < 0.001 ? NaN : minValue,
-      max: Math.abs(maxValue - domain[1]) < 0.001 ? NaN : maxValue
+      min: minValue === domain[0] ? NaN : minValue,
+      max: maxValue === domain[1] ? NaN : maxValue
     }),
     edit: (value, attachment) => {
       return new Promise((resolve) => {


### PR DESCRIPTION
Closes #188 for LineUpJS v4

**Note:** I've also pushed a branch fixing this issue in LineUpJS v3. See https://github.com/lineupjs/lineupjs/tree/clehner/188_LineUpv3_fix_number_filter 

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [ ] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+



### Summary

By comparing the filter's minValue with the domain[0] value and the filter's maxValue with the domain[1] value directly this check should also work for very small numbers, e.g. p-values. Otherwise the with very small numbers the delta of 0.001 is not reached, e.g. 
```JS
const minValue = 0.000011539572;
const minDomainValue = 7.8e-9;
Math.abs(minValue  - minDomainValue) < 0.001 ? NaN : minValue
```
