### PR TITLE
Group by string value in StringColumn

### DIFF
--- a/demo/string_grouping.html
+++ b/demo/string_grouping.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+  <meta charset="UTF-8">
+  <title>LineUp String Grouping Test</title>
+
+  <link href="./LineUpJS.css" rel="stylesheet">
+  <link href="./demo.css" rel="stylesheet">
+</head>
+<body>
+<script src="https://d3js.org/d3.v4.min.js"></script>
+<script src="./LineUpJS.js"></script>
+
+<script>
+  window.onload = function () {
+    const arr = [];
+    for (let i = 0; i < 1000; ++i) {
+      arr.push({
+        a: Math.random() * 10,
+        d: 'Row ' + i,
+        group: Math.floor(Math.random() * 2000).toString()
+      })
+    }
+    const builder = LineUpJS.builder(arr);
+    builder.deriveColumns();
+    // and two rankings
+    const ranking = LineUpJS.buildRanking()
+      .supportTypes()
+      .allColumns() // add all columns
+
+    builder
+      .ranking(ranking);
+
+
+    builder.buildTaggle(document.body);
+  };
+</script>
+
+</body>
+</html>

--- a/demo/string_grouping.html
+++ b/demo/string_grouping.html
@@ -14,19 +14,19 @@
 <script>
   window.onload = function () {
     const arr = [];
-    for (let i = 0; i < 1000; ++i) {
+    for (let i = 0; i < 5000; ++i) {
       arr.push({
-        a: Math.random() * 10,
-        d: 'Row ' + i,
         group: Math.floor(Math.random() * 2000).toString()
-      })
+      });
     }
     const builder = LineUpJS.builder(arr);
-    builder.deriveColumns();
+
+    builder
+      .column(LineUpJS.buildStringColumn('group'));
     // and two rankings
     const ranking = LineUpJS.buildRanking()
       .supportTypes()
-      .allColumns() // add all columns
+      .allColumns(); // add all columns
 
     builder
       .ranking(ranking);

--- a/src/model/StringColumn.ts
+++ b/src/model/StringColumn.ts
@@ -73,7 +73,7 @@ export default class StringColumn extends ValueColumn<string> {
   readonly escape: boolean;
 
   private currentGroupCriteria: IStringGroupCriteria = {
-    type: EStringGroupCriteriaType.value,
+    type: EStringGroupCriteriaType.startsWith,
     values: []
   };
 

--- a/src/model/StringColumn.ts
+++ b/src/model/StringColumn.ts
@@ -13,6 +13,17 @@ export enum EAlignment {
   right = 'right'
 }
 
+export enum EStringGroupCriteriaType {
+  value = 'value',
+  startsWith = 'startsWith',
+  regex = 'regex'
+}
+
+export interface IStringGroupCriteria {
+  type: EStringGroupCriteriaType;
+  values: (string | RegExp)[];
+}
+
 export interface IStringDesc {
   /**
    * column alignment: left, center, right
@@ -61,7 +72,10 @@ export default class StringColumn extends ValueColumn<string> {
   readonly alignment: EAlignment;
   readonly escape: boolean;
 
-  private currentGroupCriteria: (RegExp | string)[] = [];
+  private currentGroupCriteria: IStringGroupCriteria = {
+    type: EStringGroupCriteriaType.value,
+    values: []
+  };
 
   constructor(id: string, desc: Readonly<IStringColumnDesc>) {
     super(id, desc);
@@ -110,7 +124,11 @@ export default class StringColumn extends ValueColumn<string> {
       r.filter = this.currentFilter;
     }
     if (this.currentGroupCriteria) {
-      r.groupCriteria = this.currentGroupCriteria.map((d) => typeof d === 'string' ? d : `REGEX:${d.source}`);
+      const {type, values} = this.currentGroupCriteria;
+      r.groupCriteria = {
+        type,
+        values: values.map((value) => `${type}:${value instanceof RegExp && type === EStringGroupCriteriaType.regex ? value.source : value}`)
+      };
     }
     return r;
   }
@@ -122,8 +140,14 @@ export default class StringColumn extends ValueColumn<string> {
     } else {
       this.currentFilter = dump.filter || null;
     }
+
+    // tslint:disable-next-line: early-exit
     if (dump.groupCriteria) {
-      this.currentGroupCriteria = dump.groupCriteria.map((d: string) => d.startsWith('REGEX:') ? new RegExp(d.slice(6), 'gm') : d);
+      const {type, values} = <IStringGroupCriteria>dump.groupCriteria;
+      this.currentGroupCriteria = {
+        type,
+        values: values.map((value) => type === EStringGroupCriteriaType.regex ? new RegExp(<string>value, 'gm') : value)
+      };
     }
   }
 
@@ -164,16 +188,16 @@ export default class StringColumn extends ValueColumn<string> {
     this.fire([StringColumn.EVENT_FILTER_CHANGED, Column.EVENT_DIRTY_VALUES, Column.EVENT_DIRTY], this.currentFilter, this.currentFilter = filter);
   }
 
-  getGroupCriteria() {
-    return this.currentGroupCriteria.slice();
+  getGroupCriteria(): IStringGroupCriteria {
+    return this.currentGroupCriteria;
   }
 
-  setGroupCriteria(value: (string | RegExp)[]) {
-    if (equal(this.currentGroupCriteria, value)) {
+  setGroupCriteria(value: IStringGroupCriteria) {
+    if (equal(this.currentGroupCriteria, value) || value == null) {
       return;
     }
     const bak = this.getGroupCriteria();
-    this.currentGroupCriteria = value.slice();
+    this.currentGroupCriteria = value;
     this.fire([StringColumn.EVENT_GROUPING_CHANGED, Column.EVENT_DIRTY_VALUES, Column.EVENT_DIRTY], bak, value);
   }
 
@@ -194,24 +218,35 @@ export default class StringColumn extends ValueColumn<string> {
       return missingGroup;
     }
 
-    if (this.currentGroupCriteria.length === 0) {
-      return defaultGroup;
-    }
-    const value = this.getLabel(row);
+    const rowValue = this.getLabel(row);
 
-    if (!value) {
+    if (!rowValue) {
       return defaultGroup;
     }
 
-    for (const criteria of this.currentGroupCriteria) {
-      if (!((criteria instanceof RegExp && criteria.test(value)) || (typeof criteria === 'string' && value.startsWith(criteria)))) {
-        continue;
-      }
+    const {type, values} = this.currentGroupCriteria;
+    if (type === EStringGroupCriteriaType.value) {
       return {
-        name: typeof criteria === 'string' ? criteria : criteria.source,
+        name: rowValue,
         color: defaultGroup.color
       };
     }
+    for (const value of values) {
+      if (type === EStringGroupCriteriaType.startsWith && typeof value === 'string' && rowValue.startsWith(value)) {
+        return {
+          name: value,
+          color: defaultGroup.color
+        };
+      }
+      // tslint:disable-next-line: early-exit
+      if (type === EStringGroupCriteriaType.regex && value instanceof RegExp && value.test(rowValue)) {
+        return {
+          name: value.source,
+          color: defaultGroup.color
+        };
+      }
+    }
+
     return defaultGroup;
   }
 }

--- a/src/ui/dialogs/groupString.ts
+++ b/src/ui/dialogs/groupString.ts
@@ -1,42 +1,53 @@
 import {IDialogContext} from './ADialog';
 import StringColumn from '../../model/StringColumn';
-
+import {EStringGroupCriteriaType} from '../../model/StringColumn';
 
 /** @internal */
 export default function append(col: StringColumn, node: HTMLElement, dialog: IDialogContext) {
   const current = col.getGroupCriteria();
-  const isRegex = current.length > 0 && current[0] instanceof RegExp;
+  const {type, values} = current;
+
   node.insertAdjacentHTML('beforeend', `
     <div class="lu-checkbox">
-      <input type="radio" name="regex" value="startsWith" id="${dialog.idPrefix}RW" ${!isRegex ? 'checked' : ''}>
+      <input type="radio" name="${dialog.idPrefix}groupString" value="${EStringGroupCriteriaType.value}" id="${dialog.idPrefix}VAL" ${type === EStringGroupCriteriaType.value ? 'checked' : ''}>
+      <label for="${dialog.idPrefix}VAL">Use text value</label>
+    </div>
+    <div class="lu-checkbox">
+      <input type="radio" name="${dialog.idPrefix}groupString" value="${EStringGroupCriteriaType.startsWith}" id="${dialog.idPrefix}RW" ${type === EStringGroupCriteriaType.startsWith ? 'checked' : ''}>
       <label for="${dialog.idPrefix}RW">Text starts with &hellip;</label>
     </div>
     <div class="lu-checkbox">
-      <input type="radio" name="regex" value="regex" id="${dialog.idPrefix}RE" ${isRegex ? 'checked' : ''}>
+      <input type="radio" name="${dialog.idPrefix}groupString" value="${EStringGroupCriteriaType.regex}" id="${dialog.idPrefix}RE" ${type === EStringGroupCriteriaType.regex ? 'checked' : ''}>
       <label for="${dialog.idPrefix}RE">Use regular expressions</label>
     </div>
-    <textarea required rows="5" placeholder="e.g. Test,a.*" id="${dialog.idPrefix}T">${current.map((d) => typeof d === 'string' ? d : d.source).join('\n')}</textarea>
+    <textarea required rows="5" placeholder="e.g. Test,a.*" id="${dialog.idPrefix}T">${values.map((value) => value instanceof RegExp ? value.source : value).join('\n')}</textarea>
     <button id="${dialog.idPrefix}A">Apply</button>
   `);
 
   const button = node.querySelector<HTMLButtonElement>(`#${dialog.idPrefix}A`)!;
-  const isRegexCheck = node.querySelector<HTMLInputElement>(`#${dialog.idPrefix}RE`)!;
-  const groups = node.querySelector<HTMLTextAreaElement>(`#${dialog.idPrefix}T`)!;
+  const text = node.querySelector<HTMLTextAreaElement>(`#${dialog.idPrefix}T`)!;
 
   button.onclick = (evt) => {
     evt.preventDefault();
     evt.stopPropagation();
+    const checkedNode = node.querySelector<HTMLInputElement>(`input[name="${dialog.idPrefix}groupString"]:checked`)!;
+    const newType = <EStringGroupCriteriaType>checkedNode.value;
+    let items: (string | RegExp)[] = text.value.trim().split('\n').map((d) => d.trim()).filter((d) => d.length > 0);
 
-    let items: (string | RegExp)[] = groups.value.trim().split('\n').map((d) => d.trim()).filter((d) => d.length > 0);
-    const invalid = items.length === 0;
-    groups.setCustomValidity(invalid ? 'At least one group is required' : '');
-    if (invalid) {
-      (<any>groups).reportValidity(); // typedoc not uptodate
-      return;
+    if (newType !== EStringGroupCriteriaType.value) {
+      const invalid = items.length === 0;
+      text.setCustomValidity(invalid ? 'At least one entry is required' : '');
+      if (invalid) {
+        (<any>text).reportValidity(); // typedoc not uptodate
+        return;
+      }
     }
-    if (isRegexCheck.checked) {
+    if (newType === EStringGroupCriteriaType.regex) {
       items = items.map((d) => new RegExp(d.toString(), 'gm'));
     }
-    col.setGroupCriteria(items);
+    col.setGroupCriteria({
+      type: newType,
+      values: items
+    });
   };
 }

--- a/src/ui/dialogs/groupString.ts
+++ b/src/ui/dialogs/groupString.ts
@@ -20,12 +20,19 @@ export default function append(col: StringColumn, node: HTMLElement, dialog: IDi
       <input type="radio" name="${dialog.idPrefix}groupString" value="${EStringGroupCriteriaType.regex}" id="${dialog.idPrefix}RE" ${type === EStringGroupCriteriaType.regex ? 'checked' : ''}>
       <label for="${dialog.idPrefix}RE">Use regular expressions</label>
     </div>
-    <textarea required rows="5" placeholder="e.g. Test,a.*" id="${dialog.idPrefix}T">${values.map((value) => value instanceof RegExp ? value.source : value).join('\n')}</textarea>
+    <textarea required ${type === EStringGroupCriteriaType.value ? 'disabled' : ''} rows="5" placeholder="e.g. Test,a.*" id="${dialog.idPrefix}T">${values.map((value) => value instanceof RegExp ? value.source : value).join('\n')}</textarea>
     <button id="${dialog.idPrefix}A">Apply</button>
   `);
 
   const button = node.querySelector<HTMLButtonElement>(`#${dialog.idPrefix}A`)!;
+  const valueRadioButton = node.querySelector<HTMLInputElement>(`#${dialog.idPrefix}VAL`)!;
+  const startsWithRadioButton = node.querySelector<HTMLInputElement>(`#${dialog.idPrefix}RW`)!;
+  const regexRadioButton = node.querySelector<HTMLInputElement>(`#${dialog.idPrefix}RE`)!;
   const text = node.querySelector<HTMLTextAreaElement>(`#${dialog.idPrefix}T`)!;
+
+  valueRadioButton.onchange = () => text.disabled = valueRadioButton.checked;
+  startsWithRadioButton.onchange = () => text.disabled = !startsWithRadioButton.checked;
+  regexRadioButton.onchange = () => text.disabled = !regexRadioButton.checked;
 
   button.onclick = (evt) => {
     evt.preventDefault();

--- a/src/ui/dialogs/groupString.ts
+++ b/src/ui/dialogs/groupString.ts
@@ -20,7 +20,7 @@ export default function append(col: StringColumn, node: HTMLElement, dialog: IDi
       <input type="radio" name="${dialog.idPrefix}groupString" value="${EStringGroupCriteriaType.regex}" id="${dialog.idPrefix}RE" ${type === EStringGroupCriteriaType.regex ? 'checked' : ''}>
       <label for="${dialog.idPrefix}RE">Use regular expressions</label>
     </div>
-    <textarea required ${type === EStringGroupCriteriaType.value ? 'disabled' : ''} rows="5" placeholder="e.g. Test,a.*" id="${dialog.idPrefix}T">${values.map((value) => value instanceof RegExp ? value.source : value).join('\n')}</textarea>
+    <textarea required rows="5" placeholder="e.g. Test,a.*" id="${dialog.idPrefix}T">${values.map((value) => value instanceof RegExp ? value.source : value).join('\n')}</textarea>
     <button id="${dialog.idPrefix}A">Apply</button>
   `);
 
@@ -30,9 +30,14 @@ export default function append(col: StringColumn, node: HTMLElement, dialog: IDi
   const regexRadioButton = node.querySelector<HTMLInputElement>(`#${dialog.idPrefix}RE`)!;
   const text = node.querySelector<HTMLTextAreaElement>(`#${dialog.idPrefix}T`)!;
 
-  valueRadioButton.onchange = () => text.disabled = valueRadioButton.checked;
-  startsWithRadioButton.onchange = () => text.disabled = !startsWithRadioButton.checked;
-  regexRadioButton.onchange = () => text.disabled = !regexRadioButton.checked;
+  const showOrHideTextarea = (show: boolean) => {
+    text.style.display = show ? null : 'none';
+  };
+
+  showOrHideTextarea(type !== EStringGroupCriteriaType.value);
+  valueRadioButton.onchange = () => showOrHideTextarea(!valueRadioButton.checked);
+  startsWithRadioButton.onchange = () => showOrHideTextarea(startsWithRadioButton.checked);
+  regexRadioButton.onchange = () => showOrHideTextarea(regexRadioButton.checked);
 
   button.onclick = (evt) => {
     evt.preventDefault();


### PR DESCRIPTION
closes #192  

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
This PR adds the possibility of grouping a `StringColumn` by its actual value. It adds the option to the `groupString` dialog extension and adds a new type `EStringGroupCriteriaType` and interface `IStringGroupCriteria` to the column, allowing for more than just two criteria types (`string | RegExp` as before).

![Peek 2019-10-10 16-16](https://user-images.githubusercontent.com/51900829/66577253-5324c680-eb79-11e9-9e29-1f71df529b45.gif)
