### PR TITLE
Use font-variant-numeric

### DIFF
--- a/src/styles/renderer/_bar.scss
+++ b/src/styles/renderer/_bar.scss
@@ -14,6 +14,7 @@
     display: flex;
     justify-content: center;
     flex-direction: column;
+    font-variant-numeric: tabular-nums;
 
     > div {
       height: 100%;

--- a/src/styles/renderer/_rank.scss
+++ b/src/styles/renderer/_rank.scss
@@ -7,6 +7,7 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  font-variant-numeric: tabular-nums;
 }
 
 [data-agg=group] [data-renderer=rank] {


### PR DESCRIPTION
Closes #172 

This is a back port of PR https://github.com/lineupjs/lineupjs/pull/186.

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary

Set the font-variant-numeric as suggested
