### PR TITLE
Make renderer and utils function publicly available (i.e., remove @internal markers)

### DIFF
--- a/src/renderer/AAggregatedGroupRenderer.ts
+++ b/src/renderer/AAggregatedGroupRenderer.ts
@@ -9,7 +9,6 @@ import {noRenderer} from './utils';
 
 /**
  * helper class that renders a group renderer as a selected (e.g. median) single item
- * @internal
  */
 export abstract class AAggregatedGroupRenderer<T extends Column> implements ICellRendererFactory {
   abstract readonly title: string;
@@ -36,7 +35,4 @@ export abstract class AAggregatedGroupRenderer<T extends Column> implements ICel
   }
 }
 
-/**
- * @internal
- */
 export default AAggregatedGroupRenderer;

--- a/src/renderer/ANumbersCellRenderer.ts
+++ b/src/renderer/ANumbersCellRenderer.ts
@@ -4,7 +4,6 @@ import {INumbersColumn} from '../model/INumberColumn';
 import {default as IRenderContext, IImposer} from './interfaces';
 import {renderMissingCanvas, renderMissingDOM} from './missing';
 
-/** @internal */
 export abstract class ANumbersCellRenderer {
   abstract readonly title: string;
 

--- a/src/renderer/ActionRenderer.ts
+++ b/src/renderer/ActionRenderer.ts
@@ -4,7 +4,6 @@ import Column from '../model/Column';
 import {ERenderMode, ICellRendererFactory} from './interfaces';
 import {forEachChild, noop, noRenderer} from './utils';
 
-/** @internal */
 export default class ActionRenderer implements ICellRendererFactory {
   readonly title = 'Default';
 

--- a/src/renderer/AggregateGroupRenderer.ts
+++ b/src/renderer/AggregateGroupRenderer.ts
@@ -4,7 +4,6 @@ import Column from '../model/Column';
 import {AGGREGATE, CANVAS_HEIGHT} from '../styles';
 import {default as IRenderContext, ICellRendererFactory} from './interfaces';
 
-/** @internal */
 export default class AggregateGroupRenderer implements ICellRendererFactory {
   readonly title = 'Default';
 

--- a/src/renderer/AnnotationRenderer.ts
+++ b/src/renderer/AnnotationRenderer.ts
@@ -4,7 +4,6 @@ import Column from '../model/Column';
 import StringCellRenderer from './StringCellRenderer';
 import {noop} from './utils';
 
-/** @internal */
 export default class AnnotationRenderer extends StringCellRenderer {
   readonly title = 'Default';
 

--- a/src/renderer/BarCellRenderer.ts
+++ b/src/renderer/BarCellRenderer.ts
@@ -9,7 +9,6 @@ import {default as IRenderContext, ERenderMode, ICellRendererFactory, IImposer} 
 import {renderMissingCanvas, renderMissingDOM} from './missing';
 
 
-/** @internal */
 export default class BarCellRenderer implements ICellRendererFactory {
   readonly title = 'Bar';
 

--- a/src/renderer/BooleanCellRenderer.ts
+++ b/src/renderer/BooleanCellRenderer.ts
@@ -3,7 +3,6 @@ import Column from '../model/Column';
 import {DefaultCellRenderer} from './DefaultCellRenderer';
 import {ERenderMode} from './interfaces';
 
-/** @internal */
 export default class BooleanCellRenderer extends DefaultCellRenderer {
   readonly title = 'Default';
 

--- a/src/renderer/BoxplotCellRenderer.ts
+++ b/src/renderer/BoxplotCellRenderer.ts
@@ -10,7 +10,6 @@ import {default as IRenderContext, ERenderMode, ICellRendererFactory, IImposer} 
 import {renderMissingCanvas, renderMissingDOM} from './missing';
 import {isMapAbleColumn} from '../model/MappingFunction';
 
-/** @internal */
 export function computeLabel(v: IBoxPlotData | IAdvancedBoxPlotData) {
   if (v == null) {
     return '';
@@ -20,7 +19,6 @@ export function computeLabel(v: IBoxPlotData | IAdvancedBoxPlotData) {
   return `min = ${f(v.min)}\nq1 = ${f(v.q1)}\nmedian = ${f(v.median)}\n${mean}q3 = ${f(v.q3)}\nmax = ${f(v.max)}`;
 }
 
-/** @internal */
 export default class BoxplotCellRenderer implements ICellRendererFactory {
   readonly title = 'Box Plot';
 

--- a/src/renderer/BrightnessCellRenderer.ts
+++ b/src/renderer/BrightnessCellRenderer.ts
@@ -9,7 +9,6 @@ import {default as IRenderContext, ERenderMode, ICellRendererFactory, IImposer} 
 import {renderMissingCanvas, renderMissingDOM} from './missing';
 import {noRenderer, setText} from './utils';
 
-/** @internal */
 export function toHeatMapColor(v: number | null, row: IDataRow, col: INumberColumn, imposer?: IImposer) {
   if (v == null || isNaN(v)) {
     v = 1; // max = brightest
@@ -32,7 +31,6 @@ export function toHeatMapColor(v: number | null, row: IDataRow, col: INumberColu
   return valueColor;
 }
 
-/** @internal */
 export default class BrightnessCellRenderer implements ICellRendererFactory {
   readonly title = 'Brightness';
 

--- a/src/renderer/CategoricalCellRenderer.ts
+++ b/src/renderer/CategoricalCellRenderer.ts
@@ -11,7 +11,6 @@ import {default as IRenderContext, ICellRendererFactory} from './interfaces';
 import {renderMissingCanvas, renderMissingDOM} from './missing';
 import {setText, wideEnough, forEach} from './utils';
 
-/** @internal */
 export default class CategoricalCellRenderer implements ICellRendererFactory {
   readonly title = 'Color';
   readonly groupTitle = 'Histogram';

--- a/src/renderer/CategoricalHeatmapCellRenderer.ts
+++ b/src/renderer/CategoricalHeatmapCellRenderer.ts
@@ -7,7 +7,6 @@ import {renderMissingCanvas, renderMissingDOM} from './missing';
 import {union} from './UpSetCellRenderer';
 import {noop, wideEnough, forEachChild} from './utils';
 
-/** @internal */
 export default class CategoricalHeatmapCellRenderer implements ICellRendererFactory {
   title = 'Heatmap';
 

--- a/src/renderer/CategoricalStackedDistributionlCellRenderer.ts
+++ b/src/renderer/CategoricalStackedDistributionlCellRenderer.ts
@@ -8,7 +8,6 @@ import {interactiveHist} from './CategoricalCellRenderer';
 import {default as IRenderContext, ERenderMode, ICellRendererFactory} from './interfaces';
 import {forEachChild, noRenderer, adaptTextColorToBgColor} from './utils';
 
-/** @internal */
 export default class CategoricalStackedDistributionlCellRenderer implements ICellRendererFactory {
   readonly title = 'Distribution Bar';
 

--- a/src/renderer/CircleCellRenderer.ts
+++ b/src/renderer/CircleCellRenderer.ts
@@ -7,7 +7,6 @@ import {default as IRenderContext, ERenderMode, ICellRendererFactory, IImposer} 
 import {renderMissingDOM} from './missing';
 import {attr, noop, noRenderer, setText} from './utils';
 
-/** @internal */
 export default class CircleCellRenderer implements ICellRendererFactory {
   readonly title = 'Proportional Symbol';
 

--- a/src/renderer/DotCellRenderer.ts
+++ b/src/renderer/DotCellRenderer.ts
@@ -11,7 +11,6 @@ import {default as IRenderContext, ERenderMode, ICellRendererFactory, IImposer} 
 import {renderMissingCanvas, renderMissingDOM} from './missing';
 import {attr, forEachChild, noRenderer} from './utils';
 
-/** @internal */
 export default class DotCellRenderer implements ICellRendererFactory {
   readonly title = 'Dot';
   readonly groupTitle = 'Dots';

--- a/src/renderer/GroupCellRenderer.ts
+++ b/src/renderer/GroupCellRenderer.ts
@@ -4,7 +4,6 @@ import GroupColumn from '../model/GroupColumn';
 import {ICellRendererFactory} from './interfaces';
 import {noop, noRenderer} from './utils';
 
-/** @internal */
 export default class GroupCellRenderer implements ICellRendererFactory {
   readonly title = 'Default';
 

--- a/src/renderer/HeatmapCellRenderer.ts
+++ b/src/renderer/HeatmapCellRenderer.ts
@@ -11,7 +11,6 @@ import {IGroup} from '../model/interfaces';
 
 const GUESSED_HEIGHT = 20;
 
-/** @internal */
 export default class HeatmapCellRenderer implements ICellRendererFactory {
   readonly title = 'Heatmap';
 

--- a/src/renderer/HistogramCellRenderer.ts
+++ b/src/renderer/HistogramCellRenderer.ts
@@ -15,7 +15,6 @@ import {renderMissingDOM} from './missing';
 import {noop} from './utils';
 import {dragHandle, IDragHandleOptions} from '../internal/drag';
 
-/** @internal */
 export default class HistogramCellRenderer implements ICellRendererFactory {
   readonly title = 'Histogram';
 

--- a/src/renderer/ImageCellRenderer.ts
+++ b/src/renderer/ImageCellRenderer.ts
@@ -5,7 +5,6 @@ import {renderMissingDOM} from './missing';
 import {noop, noRenderer} from './utils';
 import LinkColumn from '../model/LinkColumn';
 
-/** @internal */
 export default class ImageCellRenderer implements ICellRendererFactory {
   readonly title = 'Image';
 

--- a/src/renderer/InterleavingCellRenderer.ts
+++ b/src/renderer/InterleavingCellRenderer.ts
@@ -11,7 +11,6 @@ import {matchColumns, forEachChild} from './utils';
 import {colorOf} from '../ui/dialogs/utils';
 
 
-/** @internal */
 export default class InterleavingCellRenderer implements ICellRendererFactory {
   readonly title = 'Interleaved';
 

--- a/src/renderer/LinkCellRenderer.ts
+++ b/src/renderer/LinkCellRenderer.ts
@@ -5,7 +5,6 @@ import {renderMissingDOM} from './missing';
 import {noop, noRenderer, setText} from './utils';
 import LinkColumn from '../model/LinkColumn';
 
-/** @internal */
 export default class LinkCellRenderer implements ICellRendererFactory {
   readonly title = 'Link';
 

--- a/src/renderer/LinkMapCellRenderer.ts
+++ b/src/renderer/LinkMapCellRenderer.ts
@@ -8,7 +8,6 @@ import LinkMapColumn from '../model/LinkMapColumn';
 import {ILink} from '../model/LinkColumn';
 import {IKeyValue} from '../model/IArrayColumn';
 
-/** @internal */
 export default class LinkMapCellRenderer implements ICellRendererFactory {
   readonly title = 'Table with Links';
 

--- a/src/renderer/LoadingCellRenderer.ts
+++ b/src/renderer/LoadingCellRenderer.ts
@@ -1,7 +1,6 @@
 import {ICellRendererFactory} from './interfaces';
 import {noop} from './utils';
 
-/** @internal */
 export default class LoadingCellRenderer implements ICellRendererFactory {
   readonly title = 'Loading';
 

--- a/src/renderer/MapBarCellRenderer.ts
+++ b/src/renderer/MapBarCellRenderer.ts
@@ -9,7 +9,6 @@ import {ICellRendererFactory, IImposer, default as IRenderContext, ERenderMode} 
 import {renderMissingDOM} from './missing';
 import {noop, noRenderer} from './utils';
 
-/** @internal */
 export default class MapBarCellRenderer implements ICellRendererFactory {
   readonly title = 'Bar Table';
 

--- a/src/renderer/MultiLevelCellRenderer.ts
+++ b/src/renderer/MultiLevelCellRenderer.ts
@@ -9,12 +9,10 @@ import {default as IRenderContext, ERenderMode, ICellRendererFactory, IImposer} 
 import {renderMissingCanvas, renderMissingDOM} from './missing';
 import {matchColumns} from './utils';
 
-/** @internal */
 export function gridClass(column: Column) {
   return `lu-stacked-${column.id}`;
 }
 
-/** @internal */
 export function createData(col: { children: Column[] } & Column, context: IRenderContext, stacked: boolean, mode: ERenderMode, imposer?: IImposer) {
   const padding = COLUMN_PADDING;
   let offset = 0;
@@ -59,7 +57,6 @@ export function createData(col: { children: Column[] } & Column, context: IRende
   return {cols, stacked, padding};
 }
 
-/** @internal */
 export default class MultiLevelCellRenderer extends AAggregatedGroupRenderer<IMultiLevelColumn & Column> implements ICellRendererFactory {
   readonly title: string;
 

--- a/src/renderer/RankCellRenderer.ts
+++ b/src/renderer/RankCellRenderer.ts
@@ -5,7 +5,6 @@ import {ICellRendererFactory} from './interfaces';
 import {renderMissingDOM} from './missing';
 import {noop, noRenderer, setText} from './utils';
 
-/** @internal */
 export default class RankCellRenderer implements ICellRendererFactory {
   readonly title = 'Default';
 

--- a/src/renderer/SelectionRenderer.ts
+++ b/src/renderer/SelectionRenderer.ts
@@ -5,7 +5,6 @@ import {default as IRenderContext, ICellRendererFactory} from './interfaces';
 import {noop} from './utils';
 import {IDataProvider} from '../provider/ADataProvider';
 
-/** @internal */
 export default class SelectionRenderer implements ICellRendererFactory {
   readonly title = 'Default';
 
@@ -75,7 +74,6 @@ export default class SelectionRenderer implements ICellRendererFactory {
   }
 }
 
-/** @internal */
 export function rangeSelection(provider: IDataProvider, rankingId: string, dataIndex: number, relIndex: number, ctrlKey: boolean) {
   const ranking = provider.getRankings().find((d) => d.id === rankingId);
   if (!ranking) { // no known reference

--- a/src/renderer/SparklineCellRenderer.ts
+++ b/src/renderer/SparklineCellRenderer.ts
@@ -7,7 +7,6 @@ import {ERenderMode, ICellRendererFactory} from './interfaces';
 import {renderMissingDOM} from './missing';
 import {forEachChild, noop, noRenderer} from './utils';
 
-/** @internal */
 export function line(data: number[]) {
   if (data.length === 0) {
     return '';
@@ -28,7 +27,6 @@ export function line(data: number[]) {
   return p;
 }
 
-/** @internal */
 export default class SparklineCellRenderer implements ICellRendererFactory {
   readonly title = 'Sparkline';
 

--- a/src/renderer/StringCellRenderer.ts
+++ b/src/renderer/StringCellRenderer.ts
@@ -10,7 +10,6 @@ import {noop, setText, uniqueId, exampleText} from './utils';
 /**
  * renders a string with additional alignment behavior
  * one instance factory shared among strings
- * @internal
  */
 export default class StringCellRenderer implements ICellRendererFactory {
   readonly title = 'Default';

--- a/src/renderer/TableCellRenderer.ts
+++ b/src/renderer/TableCellRenderer.ts
@@ -5,7 +5,6 @@ import {ICellRendererFactory} from './interfaces';
 import {renderMissingDOM} from './missing';
 import {forEach, noop} from './utils';
 
-/** @internal */
 export default class TableCellRenderer implements ICellRendererFactory {
   readonly title = 'Table';
 

--- a/src/renderer/UpSetCellRenderer.ts
+++ b/src/renderer/UpSetCellRenderer.ts
@@ -6,7 +6,6 @@ import {default as IRenderContext, ERenderMode, ICellRendererFactory} from './in
 import {renderMissingCanvas, renderMissingDOM} from './missing';
 import {noRenderer} from './utils';
 
-/** @internal */
 export default class UpSetCellRenderer implements ICellRendererFactory {
   readonly title = 'Matrix';
 

--- a/src/renderer/VerticalBarCellRenderer.ts
+++ b/src/renderer/VerticalBarCellRenderer.ts
@@ -8,7 +8,6 @@ import {toHeatMapColor} from './BrightnessCellRenderer';
 import IRenderContext, {ERenderMode, ICellRendererFactory, IImposer} from './interfaces';
 import {attr, forEachChild, noRenderer} from './utils';
 
-/** @internal */
 export default class VerticalBarCellRenderer extends ANumbersCellRenderer implements ICellRendererFactory {
   readonly title = 'Bar Chart';
 

--- a/src/renderer/utils.ts
+++ b/src/renderer/utils.ts
@@ -11,7 +11,6 @@ import {IDataRow} from '../model/interfaces';
  * @param styles
  * @param text
  * @return {T}
- * @internal
  */
 export function attr<T extends (HTMLElement | SVGElement)>(node: T, attrs: {[key: string]: any} = {}, styles: {[key: string]: any} = {}, text?: string): T {
   Object.keys(attrs).forEach((attr) => {
@@ -29,19 +28,16 @@ export function attr<T extends (HTMLElement | SVGElement)>(node: T, attrs: {[key
   return setText(node, text);
 }
 
-/** @internal */
 export function noop() {
   // no op
 }
 
-/** @internal */
 export const noRenderer = {
   template: `<div></div>`,
   update: noop,
   render: noop
 };
 
-/** @internal */
 export function setText<T extends Node>(node: T, text?: string): T {
   if (text === undefined) {
     return node;
@@ -64,13 +60,11 @@ export function setText<T extends Node>(node: T, text?: string): T {
  * @param node
  * @param selector
  * @param callback
- * @internal
  */
 export function forEach<T extends Element>(node: Element, selector: string, callback: (d: T, i: number) => void) {
   (<T[]>Array.from(node.querySelectorAll(selector))).forEach(callback);
 }
 
-/** @internal */
 export function forEachChild<T extends Element>(node: Element, callback: (d: T, i: number) => void) {
   (<T[]>Array.from(node.children)).forEach(callback);
 }
@@ -79,7 +73,6 @@ export function forEachChild<T extends Element>(node: Element, callback: (d: T, 
  * matches the columns and the dom nodes representing them
  * @param {HTMLElement} node row
  * @param columns columns to check
- * @internal
  */
 export function matchColumns(node: HTMLElement, columns: {column: Column, template: string, rendererId: string}[]) {
   if (node.childElementCount === 0) {
@@ -128,7 +121,6 @@ export function matchColumns(node: HTMLElement, columns: {column: Column, templa
   });
 }
 
-/** @internal */
 export function wideEnough(col: IArrayColumn<any>, length: number = col.labels.length) {
   const w = col.getWidth();
   return w / length > MIN_LABEL_WIDTH; // at least 30 pixel
@@ -139,7 +131,6 @@ export function wideEnough(col: IArrayColumn<any>, length: number = col.labels.l
  * Adapts the text color for a given background color
  * @param {string} bgColor as `#ff0000`
  * @returns {string} returns `black` or `white` for best contrast
- * @internal
  */
 export function adaptTextColorToBgColor(bgColor: string): string {
   return hsl(bgColor).l > 0.5 ? 'black' : 'white';
@@ -185,7 +176,6 @@ export const uniqueId: (prefix: string)=>string = (function() {
 
 const NUM_EXAMPLE_VALUES = 5;
 
-/** @internal */
 export function exampleText(col: Column, rows: IDataRow[]) {
   const examples = <string[]>[];
   for (const row of rows) {


### PR DESCRIPTION
closes #203

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [ ] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
 
* Remove `@internal` marker from Renderer, which makes them publicly available in the .d.ts files