### PR TITLE
Fixed circular reference in ScriptColumn

### DIFF
--- a/demo/script_column.html
+++ b/demo/script_column.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+  <meta charset="UTF-8">
+  <title>LineUp Script Column Test</title>
+
+  <link href="./LineUpJS.css" rel="stylesheet">
+  <link href="./demo.css" rel="stylesheet">
+</head>
+<body>
+<script src="https://d3js.org/d3.v4.min.js"></script>
+<script src="./LineUpJS.js"></script>
+
+<script>
+  window.onload = function () {
+    const arr = [];
+    for (let i = 0; i < 5000; ++i) {
+      arr.push({
+        a: Math.floor(Math.random() * 2000),
+        b: Math.floor(Math.random() * 2000)
+      });
+    }
+    const builder = LineUpJS.builder(arr);
+
+    const scriptDesc = LineUpJS.createScriptDesc('a/b');
+    scriptDesc.script = `const all = col.all; return all.byName('a').raw / all.byName('b').raw;`;
+
+    builder
+      .deriveColumns()
+      .column(scriptDesc);
+    // and a rankings
+    const ranking = LineUpJS.buildRanking()
+      .supportTypes()
+      .allColumns(); // add all columns
+
+    builder
+      .ranking(ranking);
+
+
+    builder.buildTaggle(document.body);
+  };
+</script>
+
+</body>
+</html>

--- a/src/model/ScriptColumn.ts
+++ b/src/model/ScriptColumn.ts
@@ -234,7 +234,7 @@ export default class ScriptColumn extends CompositeNumberColumn {
     const raws = <number[]>this._children.map((d) => isNumberColumn(d) ? d.getRawNumber(row) : null);
     const col = new ColumnContext(children.map((c, i) => new ColumnWrapper(c, values[i], raws[i])), () => {
       const cols = this.findMyRanker()!.flatColumns;
-      return new ColumnContext(cols.map((c) => new ColumnWrapper(c, c.getValue(row), isNumberColumn(c) ? c.getRawNumber(row) : null)));
+      return new ColumnContext(cols.filter((c) => c !== this).map((c) => new ColumnWrapper(c, c.getValue(row), isNumberColumn(c) ? c.getRawNumber(row) : null)));
     });
     return this.f.call(this, children, values, raws, col, row.v, row.i);
   }


### PR DESCRIPTION
closes #205

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
This PR fixes an issue when accessing `col.all` in a `ScriptColumn`, because the column itself was included in the column list causing an infinite loop. 
Added demo `script_column.html` for a demonstration. 