### PR TITLE
Revert D3 dependencies for LineUp v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "d3-color": "^1.2.3",
     "d3-dispatch": "^1.0.5",
     "d3-format": "^1.3.2",
-    "d3-scale": "^3.0.0",
+    "d3-scale": "^2.2.2",
     "d3-scale-chromatic": "^1.3.3",
     "d3-time": "^1.0.11",
     "d3-time-format": "^2.1.3",


### PR DESCRIPTION
Smiliar to #182 

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary

Revert major version changes of D3 dependencies in d3-array and d3-scale, as they introduce ES2015 syntax which might break older builds that are using ES5. See #181 (comment) for further information.
 
