### PR TITLE
Limit export to `toCategories()` only

### DIFF
--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -9,7 +9,8 @@ export * from './ICategoricalColumn';
 export * from './INumberColumn';
 export * from './IDateColumn';
 export * from './IArrayColumn';
-export * from './internalCategorical';
+
+export {toCategories} from './internalCategorical';
 
 export {ScaleMappingFunction, ScriptMappingFunction, mappingFunctions} from './MappingFunction';
 export {DEFAULT_CATEGORICAL_COLOR_FUNCTION, ReplacmentColorMappingFunction} from './CategoricalColorMappingFunction';


### PR DESCRIPTION
**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
 
* Addressing feedback from https://github.com/lineupjs/lineupjs/commit/f7890402257b582f64102cb70033cd88480ff9c8

