### PR TITLE
Fixed grouping of LinkColumn and exported required interfaces

### DIFF
--- a/src/model/LinkColumn.ts
+++ b/src/model/LinkColumn.ts
@@ -4,7 +4,7 @@ import {IDataRow, IGroup} from './interfaces';
 import {patternFunction} from './internal';
 import ValueColumn, {IValueColumnDesc, dataLoaded} from './ValueColumn';
 import {IEventListener} from '../internal/AEventDispatcher';
-import {IStringDesc, EAlignment} from './StringColumn';
+import {IStringDesc, EAlignment, IStringGroupCriteria, EStringGroupCriteriaType} from './StringColumn';
 import StringColumn from './StringColumn';
 
 export interface ILinkDesc extends IStringDesc {
@@ -64,7 +64,10 @@ export default class LinkColumn extends ValueColumn<string | ILink> {
   readonly patternTemplates: string[];
 
   private currentFilter: string | RegExp | null = null;
-  private currentGroupCriteria: (RegExp | string)[] = [];
+  private currentGroupCriteria: IStringGroupCriteria = {
+    type: EStringGroupCriteriaType.startsWith,
+    values: []
+  };
 
   readonly alignment: EAlignment;
   readonly escape: boolean;
@@ -188,10 +191,10 @@ export default class LinkColumn extends ValueColumn<string | ILink> {
   }
 
   getGroupCriteria() {
-    return this.currentGroupCriteria.slice();
+    return this.currentGroupCriteria;
   }
 
-  setGroupCriteria(value: (string | RegExp)[]) {
+  setGroupCriteria(value: IStringGroupCriteria) {
     return StringColumn.prototype.setGroupCriteria.call(this, value);
   }
 

--- a/src/model/StringColumn.ts
+++ b/src/model/StringColumn.ts
@@ -140,7 +140,6 @@ export default class StringColumn extends ValueColumn<string> {
     } else {
       this.currentFilter = dump.filter || null;
     }
-
     // tslint:disable-next-line: early-exit
     if (dump.groupCriteria) {
       const {type, values} = <IStringGroupCriteria>dump.groupCriteria;
@@ -193,7 +192,7 @@ export default class StringColumn extends ValueColumn<string> {
   }
 
   setGroupCriteria(value: IStringGroupCriteria) {
-    if (equal(this.currentGroupCriteria, value) || value == null) {
+    if (equal(this.currentGroupCriteria, value)) {
       return;
     }
     const bak = this.getGroupCriteria();
@@ -231,17 +230,17 @@ export default class StringColumn extends ValueColumn<string> {
         color: defaultGroup.color
       };
     }
-    for (const value of values) {
-      if (type === EStringGroupCriteriaType.startsWith && typeof value === 'string' && rowValue.startsWith(value)) {
+    for (const groupValue of values) {
+      if (type === EStringGroupCriteriaType.startsWith && typeof groupValue === 'string' && rowValue.startsWith(groupValue)) {
         return {
-          name: value,
+          name: groupValue,
           color: defaultGroup.color
         };
       }
       // tslint:disable-next-line: early-exit
-      if (type === EStringGroupCriteriaType.regex && value instanceof RegExp && value.test(rowValue)) {
+      if (type === EStringGroupCriteriaType.regex && groupValue instanceof RegExp && groupValue.test(rowValue)) {
         return {
-          name: value.source,
+          name: groupValue.source,
           color: defaultGroup.color
         };
       }

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -93,7 +93,7 @@ export {default as ScriptColumn, createScriptDesc, IScriptDesc, IScriptColumnDes
 export {default as SelectionColumn, createSelectionDesc, ISelectionColumnDesc} from './SelectionColumn';
 export {default as SetColumn, ISetColumnDesc, ISetDesc} from './SetColumn';
 export {default as StackColumn, createStackDesc} from './StackColumn';
-export {default as StringColumn, EAlignment, IStringDesc, IStringColumnDesc} from './StringColumn';
+export {default as StringColumn, EAlignment, IStringDesc, IStringColumnDesc, EStringGroupCriteriaType, IStringGroupCriteria} from './StringColumn';
 export * from './StringMapColumn';
 export {default as StringMapColumn} from './StringMapColumn';
 export * from './StringsColumn';


### PR DESCRIPTION
**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
The LinkColumn propagates the calls to the StringColumn, such that the interfaces had to be updated. And to externally set the grouping of StringColumns, it is required to export the interface used for it. 