### PR TITLE
Group by string value in StringColumn (V4)

### DIFF
--- a/demo/string_grouping.html
+++ b/demo/string_grouping.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+
+<head lang="en">
+  <meta charset="UTF-8">
+  <title>LineUp String Grouping Test</title>
+
+  <link href="./LineUpJS.css" rel="stylesheet">
+  <link href="./demo.css" rel="stylesheet">
+</head>
+
+<body>
+  <script src="https://d3js.org/d3.v4.min.js"></script>
+  <script src="./LineUpJS.js"></script>
+
+  <script>
+    window.onload = function () {
+      const arr = [];
+      for (let i = 0; i < 5000; ++i) {
+        arr.push({
+          group: Math.floor(Math.random() * 2000).toString()
+        });
+      }
+      const builder = LineUpJS.builder(arr);
+      builder
+        .column(LineUpJS.buildStringColumn('group'));
+      // and two rankings
+      const ranking = LineUpJS.buildRanking()
+        .supportTypes()
+        .allColumns(); // add all columns
+      builder
+        .ranking(ranking);
+      builder.buildTaggle(document.body);
+    };
+  </script>
+
+</body>
+
+</html>

--- a/src/model/LinkColumn.ts
+++ b/src/model/LinkColumn.ts
@@ -4,7 +4,7 @@ import {IDataRow, IGroup, IValueColumnDesc, ITypeFactory} from './interfaces';
 import {patternFunction} from './internal';
 import ValueColumn, {dataLoaded} from './ValueColumn';
 import {IEventListener, ISequence} from '../internal';
-import {IStringDesc, EAlignment} from './StringColumn';
+import {IStringDesc, EAlignment, IStringGroupCriteria, EStringGroupCriteriaType} from './StringColumn';
 import StringColumn from './StringColumn';
 
 export interface ILinkDesc extends IStringDesc {
@@ -64,7 +64,10 @@ export default class LinkColumn extends ValueColumn<string | ILink> {
   readonly patternTemplates: string[];
 
   private currentFilter: string | RegExp | null = null;
-  private currentGroupCriteria: (RegExp | string)[] = [];
+  private currentGroupCriteria: IStringGroupCriteria = {
+    type: EStringGroupCriteriaType.startsWith,
+    values: []
+  };
 
   readonly alignment: EAlignment;
   readonly escape: boolean;
@@ -193,10 +196,10 @@ export default class LinkColumn extends ValueColumn<string | ILink> {
   }
 
   getGroupCriteria() {
-    return this.currentGroupCriteria.slice();
+    return this.currentGroupCriteria;
   }
 
-  setGroupCriteria(value: (string | RegExp)[]) {
+  setGroupCriteria(value: IStringGroupCriteria) {
     return StringColumn.prototype.setGroupCriteria.call(this, value);
   }
 

--- a/src/ui/dialogs/groupString.ts
+++ b/src/ui/dialogs/groupString.ts
@@ -1,43 +1,65 @@
 import {IDialogContext} from './ADialog';
-import {StringColumn} from '../../model';
-import {cssClass} from '../../styles';
-
+import {StringColumn, EStringGroupCriteriaType} from '../../model';
+import {cssClass} from '../../styles/index';
 
 /** @internal */
 export default function append(col: StringColumn, node: HTMLElement, dialog: IDialogContext) {
   const current = col.getGroupCriteria();
-  const isRegex = current.length > 0 && current[0] instanceof RegExp;
+  const {type, values} = current;
+
   node.insertAdjacentHTML('beforeend', `
     <label class="${cssClass('checkbox')}">
-      <input type="radio" name="regex" value="startsWith" id="${dialog.idPrefix}RW" ${!isRegex ? 'checked' : ''}>
+      <input type="radio" name="${dialog.idPrefix}groupString" value="${EStringGroupCriteriaType.value}" id="${dialog.idPrefix}VAL" ${type === EStringGroupCriteriaType.value ? 'checked' : ''}>
+      <span>Use text value</span>
+    </label>
+    <label class="${cssClass('checkbox')}">
+      <input type="radio" name="${dialog.idPrefix}groupString" value="${EStringGroupCriteriaType.startsWith}" id="${dialog.idPrefix}RW" ${type === EStringGroupCriteriaType.startsWith ? 'checked' : ''}>
       <span>Text starts with &hellip;</span>
     </label>
     <label class="${cssClass('checkbox')}">
-      <input type="radio" name="regex" value="regex" id="${dialog.idPrefix}RE" ${isRegex ? 'checked' : ''}>
+      <input type="radio" name="${dialog.idPrefix}groupString" value="${EStringGroupCriteriaType.regex}" id="${dialog.idPrefix}RE" ${type === EStringGroupCriteriaType.regex ? 'checked' : ''}>
       <span>Use regular expressions</span>
     </label>
-    <textarea class="${cssClass('textarea')}" required rows="5" placeholder="e.g. Test,a.*" id="${dialog.idPrefix}T">${current.map((d) => typeof d === 'string' ? d : d.source).join('\n')}</textarea>
-    <button class="${cssClass('dialog-button')}" id="${dialog.idPrefix}A">Apply</button>
+    <textarea required rows="5" placeholder="e.g. Test,a.*" id="${dialog.idPrefix}T">${values.map((value) => value instanceof RegExp ? value.source : value).join('\n')}</textarea>
+    <button id="${dialog.idPrefix}A">Apply</button>
   `);
 
   const button = node.querySelector<HTMLButtonElement>(`#${dialog.idPrefix}A`)!;
-  const isRegexCheck = node.querySelector<HTMLInputElement>(`#${dialog.idPrefix}RE`)!;
-  const groups = node.querySelector<HTMLTextAreaElement>(`#${dialog.idPrefix}T`)!;
+  const valueRadioButton = node.querySelector<HTMLInputElement>(`#${dialog.idPrefix}VAL`)!;
+  const startsWithRadioButton = node.querySelector<HTMLInputElement>(`#${dialog.idPrefix}RW`)!;
+  const regexRadioButton = node.querySelector<HTMLInputElement>(`#${dialog.idPrefix}RE`)!;
+  const text = node.querySelector<HTMLTextAreaElement>(`#${dialog.idPrefix}T`)!;
+
+  const showOrHideTextarea = (show: boolean) => {
+    text.style.display = show ? null : 'none';
+  };
+
+  showOrHideTextarea(type !== EStringGroupCriteriaType.value);
+  valueRadioButton.onchange = () => showOrHideTextarea(!valueRadioButton.checked);
+  startsWithRadioButton.onchange = () => showOrHideTextarea(startsWithRadioButton.checked);
+  regexRadioButton.onchange = () => showOrHideTextarea(regexRadioButton.checked);
 
   button.onclick = (evt) => {
     evt.preventDefault();
     evt.stopPropagation();
+    const checkedNode = node.querySelector<HTMLInputElement>(`input[name="${dialog.idPrefix}groupString"]:checked`)!;
+    const newType = <EStringGroupCriteriaType>checkedNode.value;
+    let items: (string | RegExp)[] = text.value.trim().split('\n').map((d) => d.trim()).filter((d) => d.length > 0);
 
-    let items: (string | RegExp)[] = groups.value.trim().split('\n').map((d) => d.trim()).filter((d) => d.length > 0);
-    const invalid = items.length === 0;
-    groups.setCustomValidity(invalid ? 'At least one group is required' : '');
-    if (invalid) {
-      (<any>groups).reportValidity(); // typedoc not uptodate
-      return;
+    if (newType !== EStringGroupCriteriaType.value) {
+      const invalid = items.length === 0;
+      text.setCustomValidity(invalid ? 'At least one entry is required' : '');
+      if (invalid) {
+        (<any>text).reportValidity(); // typedoc not uptodate
+        return;
+      }
     }
-    if (isRegexCheck.checked) {
+    if (newType === EStringGroupCriteriaType.regex) {
       items = items.map((d) => new RegExp(d.toString(), 'gm'));
     }
-    col.setGroupCriteria(items);
+    col.setGroupCriteria({
+      type: newType,
+      values: items
+    });
   };
 }


### PR DESCRIPTION
LineUp 4 Port of #193

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
This PR adds the possibility of grouping a `StringColumn` by its actual value. It adds the option to the `groupString` dialog extension and adds a new type `EStringGroupCriteriaType` and interface `IStringGroupCriteria` to the column, allowing for more than just two criteria types (`string | RegExp` as before).

![Peek 2019-10-10 16-16](https://user-images.githubusercontent.com/51900829/66577253-5324c680-eb79-11e9-9e29-1f71df529b45.gif)