### PR TITLE
Export StringGroupCriteria interfaces from StringColumn

### DIFF
--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -93,7 +93,7 @@ export {default as ScriptColumn, createScriptDesc, IScriptDesc, IScriptColumnDes
 export {default as SelectionColumn, createSelectionDesc, ISelectionColumnDesc} from './SelectionColumn';
 export {default as SetColumn, ISetColumnDesc, ISetDesc} from './SetColumn';
 export {default as StackColumn, createStackDesc} from './StackColumn';
-export {default as StringColumn, EAlignment, IStringDesc, IStringColumnDesc} from './StringColumn';
+export {default as StringColumn, EAlignment, IStringGroupCriteria, EStringGroupCriteriaType, IStringDesc, IStringColumnDesc} from './StringColumn';
 export * from './StringMapColumn';
 export {default as StringMapColumn} from './StringMapColumn';
 export * from './StringsColumn';


### PR DESCRIPTION
closes #221 

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
The two exports are missing from LineUp#V3 (V4 exports everything by default) but required to set the string grouping criteria in a type-safe way. 