### PR TITLE
Fix canvas horizontal shift issue

### DIFF
--- a/demo/wide.html
+++ b/demo/wide.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+  <meta charset="UTF-8">
+  <title>LineUp Builder Test</title>
+
+  <link href="./LineUpJS.css" rel="stylesheet">
+  <link href="./demo.css" rel="stylesheet">
+</head>
+<body>
+<script src="./LineUpJS.js"></script>
+<script src="./helper/testRules.js"></script>
+
+<script>
+  window.onload = function () {
+    const arr = [];
+    const l = new Array(10).fill(0);
+    const cats = ['c1', 'c2', 'c3', 'c4', 'c5', 'c6'];
+    for (let i = 0; i < 100; ++i) {
+      arr.push({
+        cat: cats[Math.floor(Math.random() * 3) + 0],
+        cat2: cats[Math.floor(Math.random() * 3) + 1],
+        cat3: cats[Math.floor(Math.random() * 3) + 2],
+        cat4: cats[Math.floor(Math.random() * 3) + 3],
+      })
+    }
+    const builder = LineUpJS.builder(arr);
+    builder.deriveColumns().animated(false)
+      .overviewMode();
+    // and two rankings
+    const ranking = LineUpJS.buildRanking()
+      .supportTypes()
+      .allColumns() // add all columns
+      .column('cat').column('cat2').column("cat3")
+      .groupBy('cat')
+
+    builder
+      .ranking((data) => {
+        const r = ranking.build(data);
+        r.children.slice(3).forEach((c) => c.setWidth(300));
+        return r;
+      });
+
+
+    builder.buildTaggle(document.body);
+  };
+</script>
+
+</body>
+</html>

--- a/src/ui/EngineRanking.ts
+++ b/src/ui/EngineRanking.ts
@@ -87,7 +87,9 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
   private readonly selection: SelectionManager;
   private highlight: number = -1;
   private readonly canvasPool: HTMLCanvasElement[] = [];
-  private oldLeft: number = 0;
+
+  private currentCanvasShift: number = 0;
+  private currentCanvasWidth: number = 0;
 
   private readonly events = new RankingEvents();
 
@@ -265,6 +267,8 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
       #${tableIds(this.tableId).tbody} > .${engineCssClass('tr')}.${engineCssClass('highlighted')} .${cssClass('hover-only')}`, {
         visibility: 'visible'
       });
+
+    this.updateCanvasRule();
   }
 
   on(type: typeof EngineRanking.EVENT_WIDTH_CHANGED, listener: typeof widthChanged | null): this;
@@ -335,7 +339,9 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
     if (this.canvasPool.length > 0) {
       return this.canvasPool.pop()!;
     }
-    return this.body.ownerDocument!.createElement('canvas');
+    const c = this.body.ownerDocument!.createElement('canvas');
+    c.classList.add(cssClass(`low-c${this.tableId}`));
+    return c;
   }
 
   private rowFlags(row: HTMLElement) {
@@ -393,7 +399,7 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
     }
   }
 
-  private renderRow(canvas: HTMLCanvasElement, node: HTMLElement, index: number, width = this.visibleRenderedWidth()) {
+  private renderRow(canvas: HTMLCanvasElement, node: HTMLElement, index: number) {
     if (this.loadingCanvas.has(canvas)) {
       for (const a of this.loadingCanvas.get(canvas)!) {
         a.render.abort();
@@ -402,8 +408,7 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
     }
     canvas.classList.remove(cssClass('loading-c'));
 
-    canvas.width = width;
-    canvas.style.width = `${width}px`;
+    canvas.width = this.currentCanvasWidth;
     canvas.height = CANVAS_HEIGHT;
     const ctx = canvas.getContext('2d')!;
     ctx.imageSmoothingEnabled = false;
@@ -485,7 +490,6 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
 
 
   protected updateCanvasCell(canvas: HTMLCanvasElement, node: HTMLElement, index: number, column: RenderColumn, x: number) {
-
     // delete lazy that would render the same thing
     if (this.loadingCanvas.has(canvas)) {
       const l = this.loadingCanvas.get(canvas)!;
@@ -615,6 +619,7 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
   }
 
   protected updateRow(node: HTMLElement, rowIndex: number, hoverLod?: 'high' | 'low'): void {
+    console.log('update row', rowIndex);
     this.roptions.customRowUpdate(node, rowIndex);
 
     const computedLod = this.roptions.levelOfDetail(rowIndex);
@@ -692,10 +697,10 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
   }
 
   private updateCanvasBody() {
-    const width = this.visibleRenderedWidth();
+    this.updateCanvasRule();
     super.forEachRow((row, index) => {
       if (EngineRanking.isCanvasRenderedRow(row)) {
-        this.renderRow(<HTMLCanvasElement>row.firstElementChild!, row, index, width);
+        this.renderRow(<HTMLCanvasElement>row.firstElementChild!, row, index);
       }
     });
   }
@@ -706,13 +711,23 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
     return toRowMeta(this.renderCtx.getRow(rowIndex), provider.getAggregationStrategy(), topNGetter);
   }
 
+  private updateCanvasRule() {
+    this.style.updateRule(`renderCanvas${this.tableId}`, `.${cssClass(`low-c${this.tableId}`)}`, {
+        transform: `translateX(${this.currentCanvasShift}px)`,
+        width: `${this.currentCanvasWidth}px`
+      });
+  }
+
   protected updateShifts(top: number, left: number) {
     super.updateShifts(top, left);
 
-    if (left === this.oldLeft) {
+    const width = this.visibleRenderedWidth();
+    if (left === this.currentCanvasShift && width === this.currentCanvasWidth) {
       return;
     }
-    this.oldLeft = left;
+
+    this.currentCanvasShift = left;
+    this.currentCanvasWidth = width;
     this.updateCanvasBody();
   }
 
@@ -843,6 +858,7 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
   destroy() {
     super.destroy();
     this.style.deleteRule(`hoverOnly${this.tableId}`);
+    this.style.deleteRule(`renderCanvas${this.tableId}`);
     this.ranking.flatColumns.forEach((c) => EngineRanking.disableListener(c));
   }
 

--- a/src/ui/EngineRanking.ts
+++ b/src/ui/EngineRanking.ts
@@ -619,7 +619,6 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
   }
 
   protected updateRow(node: HTMLElement, rowIndex: number, hoverLod?: 'high' | 'low'): void {
-    console.log('update row', rowIndex);
     this.roptions.customRowUpdate(node, rowIndex);
 
     const computedLod = this.roptions.levelOfDetail(rowIndex);


### PR DESCRIPTION
closes #224

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [ ] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary

before:

![before](https://user-images.githubusercontent.com/4129778/74866871-952cf880-5321-11ea-9685-187e79fe802c.gif)

after:

![scrollbug](https://user-images.githubusercontent.com/4129778/74866877-978f5280-5321-11ea-97e1-adfc6e085513.gif)

the issue was the the canvas rendering logic didn't consider the optimized horizontal rendering logic. Thus, didn't update when a column to the left was not rendered anymore (shift to left) or the width changes (missing content on the right)
