### PR TITLE
Set title prop in StringCellRenderer

### DIFF
--- a/src/renderer/StringCellRenderer.ts
+++ b/src/renderer/StringCellRenderer.ts
@@ -24,13 +24,12 @@ export default class StringCellRenderer implements ICellRendererFactory {
       template: `<div${align !== 'left' ? ` class="lu-${align}"` : ''}> </div>`,
       update: (n: HTMLDivElement, d: IDataRow) => {
         renderMissingDOM(n, col, d);
-        const label = col.getLabel(d);
         if (col.escape) {
-          setText(n, label);
+          setText(n, col.getLabel(d));
         } else {
-          n.innerHTML = label;
-          n.title = label;
+          n.innerHTML = col.getLabel(d);
         }
+        n.title = n.textContent!;
       },
       render: noop
     };

--- a/src/renderer/StringCellRenderer.ts
+++ b/src/renderer/StringCellRenderer.ts
@@ -24,10 +24,12 @@ export default class StringCellRenderer implements ICellRendererFactory {
       template: `<div${align !== 'left' ? ` class="lu-${align}"` : ''}> </div>`,
       update: (n: HTMLDivElement, d: IDataRow) => {
         renderMissingDOM(n, col, d);
+        const label = col.getLabel(d);
         if (col.escape) {
-          setText(n, col.getLabel(d));
+          setText(n, label);
         } else {
-          n.innerHTML = col.getLabel(d);
+          n.innerHTML = label;
+          n.title = label;
         }
       },
       render: noop
@@ -44,6 +46,7 @@ export default class StringCellRenderer implements ICellRendererFactory {
           setText(n, v);
         } else {
           n.innerHTML = v;
+          n.title = v;
         }
       }
     };

--- a/src/renderer/utils.ts
+++ b/src/renderer/utils.ts
@@ -52,6 +52,9 @@ export function setText<T extends Node>(node: T, text?: string): T {
   if (node.textContent !== text) {
     node.textContent = text;
   }
+  if (node instanceof HTMLElement && node.title !== text) {
+    node.title = text;
+  }
   return node;
 }
 

--- a/src/renderer/utils.ts
+++ b/src/renderer/utils.ts
@@ -52,9 +52,6 @@ export function setText<T extends Node>(node: T, text?: string): T {
   if (node.textContent !== text) {
     node.textContent = text;
   }
-  if (node instanceof HTMLElement && node.title !== text) {
-    node.title = text;
-  }
   return node;
 }
 


### PR DESCRIPTION
closes #223 

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
Added `title` property to nodes rendered with `StringCellRenderer` to show a tooltip of the text on hover. 
