### PR TITLE
Fix removal of filtered column

### DIFF
--- a/src/model/CompositeColumn.ts
+++ b/src/model/CompositeColumn.ts
@@ -206,7 +206,11 @@ export default class CompositeColumn extends Column implements IColumnParent {
   protected removeImpl(col: Column, index: number) {
     col.detach();
     this.unforward(col, ...suffix('.combine', Column.EVENT_DIRTY_HEADER, Column.EVENT_DIRTY_VALUES, Column.EVENT_DIRTY, CompositeColumn.EVENT_FILTER_CHANGED));
-    this.fire([CompositeColumn.EVENT_REMOVE_COLUMN, Column.EVENT_DIRTY_HEADER, Column.EVENT_DIRTY_VALUES, Column.EVENT_DIRTY], col, index);
+    const events = [CompositeColumn.EVENT_REMOVE_COLUMN, Column.EVENT_DIRTY_HEADER, Column.EVENT_DIRTY_VALUES, Column.EVENT_DIRTY];
+    if (col.isFiltered()) {
+      events.splice(1, 0, CompositeColumn.EVENT_FILTER_CHANGED);
+    }
+    this.fire(events, col, index);
     return true;
   }
 

--- a/src/model/Ranking.ts
+++ b/src/model/Ranking.ts
@@ -649,6 +649,8 @@ export default class Ranking extends AEventDispatcher implements IColumnParent {
       this.triggerResort(null);
     } else if (groupSortCriteriaChanged) {
       this.triggerGroupResort(null);
+    } else if (col.isFiltered()) {
+      this.dirtyOrder();
     }
 
     return true;


### PR DESCRIPTION
closes #248

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [ ] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
 
upon removing a filtered column that wasn't influencing the ranking order it wasn't detected as something that actually makes the ranking invalid. 