### PR TITLE
Add subtitle / summary to column headers

### DIFF
--- a/demo/subtitle_summary.html
+++ b/demo/subtitle_summary.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+  <meta charset="UTF-8">
+  <title>LineUp Builder Test</title>
+
+  <link href="./LineUpJS.css" rel="stylesheet">
+  <link href="./demo.css" rel="stylesheet">
+</head>
+<body>
+<script src="https://d3js.org/d3.v4.min.js"></script>
+<script src="./LineUpJS.js"></script>
+
+<script>
+  window.onload = function () {
+    const arr = [];
+    const cats = ['c1', 'c2', 'c3'];
+    for (let i = 0; i < 100; ++i) {
+      arr.push({
+        s: 'Row ' + i,
+        a: Math.random() * 10,
+        cat: cats[Math.floor(Math.random() * 3)],
+        d: new Date(Date.now() - Math.floor(Math.random() * 1000000000000))
+      });
+    }
+    const builder = LineUpJS.builder(arr);
+
+    builder
+      .deriveColumns()
+      .column(LineUpJS.buildStringColumn('s').summary('Test'))
+
+    const lineup = builder.build(document.body);
+
+  };
+</script>
+
+</body>
+</html>

--- a/demo/subtitle_summary.html
+++ b/demo/subtitle_summary.html
@@ -28,6 +28,9 @@
     builder
       .deriveColumns()
       .column(LineUpJS.buildStringColumn('s').summary('Test'))
+      .column(LineUpJS.buildStringColumn('s').label('Long label that will take up space').summary('Test'))
+      .column(LineUpJS.buildStringColumn('s').label('Teset').summary('Long summary that will take up space'))
+      .column(LineUpJS.buildStringColumn('s').label('Long label that will take up space2').summary('Long summary that will take up space'))
 
     const lineup = builder.build(document.body);
 

--- a/src/builder/column/ColumnBuilder.ts
+++ b/src/builder/column/ColumnBuilder.ts
@@ -16,6 +16,14 @@ export default class ColumnBuilder<T extends IColumnDesc = IColumnDesc> {
   }
 
   /**
+   * column summary text (subtitle)
+   */
+  summary(summary: string) {
+    this.desc.summary = summary;
+    return this;
+  }
+
+  /**
    * column description
    */
   description(description: string) {

--- a/src/model/Column.ts
+++ b/src/model/Column.ts
@@ -136,6 +136,7 @@ export default class Column extends AEventDispatcher {
 
     this.metadata = {
       label: desc.label || this.id,
+      summary: desc.summary || '',
       description: desc.description || ''
     };
   }
@@ -252,13 +253,14 @@ export default class Column extends AEventDispatcher {
   }
 
   setMetaData(value: Readonly<IColumnMetaData>) {
-    if (value.label === this.label && this.description === value.description) {
+    if (value.label === this.label && this.description === value.description && this.metadata.summary === value.summary) {
       return;
     }
     const bak = this.getMetaData();
     //copy to avoid reference
     this.metadata = {
       label: value.label,
+      summary: value.summary,
       description: value.description
     };
 
@@ -420,6 +422,9 @@ export default class Column extends AEventDispatcher {
     if (this.label !== (this.desc.label || this.id)) {
       r.label = this.label;
     }
+    if (this.metadata.summary) {
+      r.summary = this.metadata.summary;
+    }
     if (this.getRenderer() !== this.desc.type) {
       r.renderer = this.getRenderer();
     }
@@ -441,6 +446,7 @@ export default class Column extends AEventDispatcher {
     this.width = dump.width || this.width;
     this.metadata = {
       label: dump.label || this.label,
+      summary: dump.summary || '',
       description: this.description
     };
     if (dump.renderer || dump.rendererType) {

--- a/src/model/interfaces.ts
+++ b/src/model/interfaces.ts
@@ -17,6 +17,11 @@ export interface IStyleColumn {
   description: string;
 
   /**
+   * column summary line (subtitle)
+   */
+  summary: string;
+
+  /**
    * color of this column
    * @deprecated not used anymore
    */
@@ -127,6 +132,7 @@ export interface IColumnParent {
 
 export interface IColumnMetaData {
   label: string;
+  summary: string;
   description: string;
 }
 
@@ -217,6 +223,7 @@ export interface IColumnDump {
   width?: number;
   desc: any;
   label?: string;
+  summary?: string;
   renderer?: string;
   /**
    * @deprecated

--- a/src/styles/engine/_header.scss
+++ b/src/styles/engine/_header.scss
@@ -39,6 +39,16 @@
   font-weight: 500;
 }
 
+.#{$lu_css_prefix}-th-sublabel {
+  text-align: center;
+  margin-right: $lu-engine_grip_gap;
+  display: none;
+}
+
+.#{$lu_css_prefix}-show-sublabel > .#{$lu_css_prefix}-header > .#{$lu_css_prefix}-sublabel {
+  display: unset;
+}
+
 .#{$lu_css_prefix}-th-summary {
   height: 2em;
 

--- a/src/styles/header/_index.scss
+++ b/src/styles/header/_index.scss
@@ -39,6 +39,13 @@
   text-overflow: ellipsis;
 }
 
+.#{$lu_css_prefix}-sublabel {
+  white-space: nowrap;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  font-size: smaller;
+}
+
 .#{$lu_css_prefix}-spacing {
   flex: 1;
 }

--- a/src/styles/panel/_entry.scss
+++ b/src/styles/panel/_entry.scss
@@ -15,12 +15,13 @@
   font-weight: 500;
 }
 
-.#{$lu_css_prefix}-side-panel-label {
+.#{$lu_css_prefix}-side-panel-labels {
   margin: 0 1em 0 0;
   padding: 0 0 0 0.4em;
   overflow: hidden !important;
   cursor: pointer;
   flex: 1;
+  white-space: nowrap;
 }
 
 .#{$lu_css_prefix}-side-panel-toolbar {

--- a/src/ui/EngineRanking.ts
+++ b/src/ui/EngineRanking.ts
@@ -289,6 +289,7 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
   }
 
   updateHeaders() {
+    this.updateColumnSummaryFlag();
     return super.updateHeaders();
   }
 
@@ -302,6 +303,11 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
 
   protected createHeader(_document: Document, column: RenderColumn): HTMLElement | IAsyncUpdate<HTMLElement> {
     return column.createHeader();
+  }
+
+  private updateColumnSummaryFlag() {
+    // updates the header flag depending on whether there are any sublabels
+    this.header.classList.toggle(cssClass('show-sublabel'), this.columns.some((c) => c.hasSummaryLine()));
   }
 
   protected updateHeader(node: HTMLElement, column: RenderColumn) {
@@ -543,6 +549,8 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
       column: nonUniformContext(this.columns.map((w) => w.width), 100, COLUMN_PADDING)
     });
 
+    this.updateColumnSummaryFlag();
+
     this.events.fire(EngineRanking.EVENT_RECREATE);
     super.recreate();
     this.events.fire(EngineRanking.EVENT_WIDTH_CHANGED);
@@ -566,6 +574,7 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
     if (node && column) {
       this.updateHeader(node, column);
     }
+    this.updateColumnSummaryFlag();
     return node && column;
   }
 

--- a/src/ui/MultiLevelRenderColumn.ts
+++ b/src/ui/MultiLevelRenderColumn.ts
@@ -107,6 +107,10 @@ export default class MultiLevelRenderColumn extends RenderColumn {
     return this.updateNested(wrapper, r);
   }
 
+  hasSummaryLine() {
+    return Boolean(this.c.getMetaData().summary) || this.mc.children.some((c) => c.getMetaData().summary);
+  }
+
   updateWidthRule(style: StyleManager) {
     const mc = this.mc;
     // need this for chrome to work properly

--- a/src/ui/MultiLevelRenderColumn.ts
+++ b/src/ui/MultiLevelRenderColumn.ts
@@ -108,7 +108,7 @@ export default class MultiLevelRenderColumn extends RenderColumn {
   }
 
   hasSummaryLine() {
-    return Boolean(this.c.getMetaData().summary) || this.mc.children.some((c) => Boolean(c.getMetaData().summary));
+    return super.hasSummaryLine() || this.mc.children.some((c) => Boolean(c.getMetaData().summary));
   }
 
   updateWidthRule(style: StyleManager) {

--- a/src/ui/MultiLevelRenderColumn.ts
+++ b/src/ui/MultiLevelRenderColumn.ts
@@ -108,7 +108,7 @@ export default class MultiLevelRenderColumn extends RenderColumn {
   }
 
   hasSummaryLine() {
-    return Boolean(this.c.getMetaData().summary) || this.mc.children.some((c) => c.getMetaData().summary);
+    return Boolean(this.c.getMetaData().summary) || this.mc.children.some((c) => Boolean(c.getMetaData().summary));
   }
 
   updateWidthRule(style: StyleManager) {

--- a/src/ui/RenderColumn.ts
+++ b/src/ui/RenderColumn.ts
@@ -106,6 +106,10 @@ export default class RenderColumn implements IColumn {
     return this.updateHeader(node);
   }
 
+  hasSummaryLine() {
+    return Boolean(this.c.getMetaData().summary);
+  }
+
   updateHeader(node: HTMLElement): HTMLElement | IAsyncUpdate<HTMLElement> {
     updateHeader(node, this.c);
     if (!this.renderers || !this.renderers.summary) {

--- a/src/ui/dialogs/RenameDialog.ts
+++ b/src/ui/dialogs/RenameDialog.ts
@@ -18,19 +18,22 @@ export default class RenameDialog extends ADialog {
     node.classList.add(cssClass('dialog-rename'));
     node.insertAdjacentHTML('beforeend', `
       <input type="text" value="${this.column.label}" required autofocus placeholder="name">
+      <input type="text" value="${this.column.getMetaData().summary}" placeholder="summary" name="summary">
       <textarea class="${cssClass('textarea')}" rows="5" placeholder="description">${this.column.description}</textarea>`);
   }
 
   protected reset() {
     this.findInput('input[type="text"]').value = this.before.label;
+    this.findInput('input[name="summary"]').value = this.before.summary;
     this.node.querySelector('textarea')!.value = this.before.description;
     this.column.setMetaData(this.before);
   }
 
   protected submit() {
     const newValue = this.findInput('input[type="text"]').value;
+    const newSummary = this.findInput('input[name="summary"]').value.trim();
     const newDescription = this.node.querySelector('textarea')!.value;
-    this.column.setMetaData({label: newValue, description: newDescription});
+    this.column.setMetaData({label: newValue, description: newDescription, summary: newSummary});
     return true;
   }
 }

--- a/src/ui/header.ts
+++ b/src/ui/header.ts
@@ -31,9 +31,10 @@ export function createHeader(col: Column, ctx: IRankingHeaderContext, options: P
   const node = ctx.document.createElement('section');
 
   const extra = options.extraPrefix ? (name: string) => `${cssClass(name)} ${cssClass(`${options.extraPrefix}-${name}`)}` : cssClass;
-
+  const summary = col.getMetaData().summary;
   node.innerHTML = `
     <div class="${extra('label')} ${cssClass('typed-icon')}">${col.getWidth() < MIN_LABEL_WIDTH ? '&nbsp;' : col.label}</div>
+    <div class="${extra('sublabel')}">${col.getWidth() < MIN_LABEL_WIDTH || !summary ? '&nbsp;' : summary}</div>
     <div class="${extra('toolbar')}"></div>
     <div class="${extra('spacing')}"></div>
     <div class="${extra('handle')} ${cssClass('feature-advanced')} ${cssClass('feature-ui')}"></div>
@@ -65,7 +66,18 @@ export function createHeader(col: Column, ctx: IRankingHeaderContext, options: P
 export function updateHeader(node: HTMLElement, col: Column, minWidth = MIN_LABEL_WIDTH) {
   const label = <HTMLElement>node.getElementsByClassName(cssClass('label'))[0]!;
   label.innerHTML = col.getWidth() < minWidth ? '&nbsp;' : col.label;
-  node.title = col.description ? `${col.label}\n${col.description}` : col.label;
+  const summary = col.getMetaData().summary;
+  const sublabel = <HTMLElement>node.getElementsByClassName(cssClass('sublabel'))[0]!;
+  sublabel.innerHTML = col.getWidth() < minWidth || !summary ? '&nbsp;' : summary;
+
+  let title = col.label;
+  if (summary) {
+    title = `${title}\n${summary}`;
+  }
+  if (col.description) {
+    title = `${title}\n${col.description}`;
+  }
+  node.title = title;
   node.dataset.colId = col.id;
   node.dataset.type = col.desc.type;
   label.dataset.typeCat = categoryOf(col).name;

--- a/src/ui/panel/SidePanelEntryVis.ts
+++ b/src/ui/panel/SidePanelEntryVis.ts
@@ -33,7 +33,10 @@ export default class SidePanelEntryVis {
   private init() {
     this.node.innerHTML = `
       <header class="${cssClass('side-panel-entry-header')}">
-        <div class="${cssClass('label')} ${cssClass('typed-icon')} ${cssClass('side-panel-label')}"></div>
+        <div class="${cssClass('side-panel-labels')}">
+          <span class="${cssClass('label')} ${cssClass('typed-icon')} ${cssClass('side-panel-label')}"></span>
+          <span class="${cssClass('sublabel')} ${cssClass('side-panel-sublabel')}"></span>
+        </div>
         <div class="${cssClass('toolbar')} ${cssClass('side-panel-toolbar')}"></div>
       </header>`;
     createShortcutMenuItems(<HTMLElement>this.node.querySelector(`.${cssClass('toolbar')}`), 0, this.column, this.ctx, false);


### PR DESCRIPTION
closes #220 

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [ ] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary

add a new metadata field to columns `summary` which is rendered below the column label in the table. it can act as a short summary or subtitle of the column.

![2020-03-06 10_45_00-LineUp Builder Test](https://user-images.githubusercontent.com/4129778/76098672-df57e000-5f97-11ea-9b02-179e5f5cb9d6.png)

 
