### PR TITLE
Fix grouping of previously ungrouped column by matching the nested header

### DIFF
--- a/src/ui/MultiLevelRenderColumn.ts
+++ b/src/ui/MultiLevelRenderColumn.ts
@@ -53,7 +53,7 @@ export default class MultiLevelRenderColumn extends RenderColumn {
     }
 
     const lookup = new Map((<HTMLElement[]>Array.from(wrapper.children)).map((n: HTMLElement, i) =>
-      ([n.dataset.colId!, {node: n, summary: this.summaries[i]}] as [string, {node: HTMLElement, summary: ISummaryRenderer}]))
+      (<[string, {node: HTMLElement, summary: ISummaryRenderer}]>[n.dataset.colId!, {node: n, summary: this.summaries[i]}]))
     );
 
     // reset summaries array

--- a/src/ui/MultiLevelRenderColumn.ts
+++ b/src/ui/MultiLevelRenderColumn.ts
@@ -53,7 +53,7 @@ export default class MultiLevelRenderColumn extends RenderColumn {
     }
 
     const lookup = new Map((<HTMLElement[]>Array.from(wrapper.children)).map((n: HTMLElement, i) =>
-      ([n.dataset.colId!, {node: n, summary: this.summaries[i]}]))
+      ([n.dataset.colId!, {node: n, summary: this.summaries[i]}] as [string, {node: HTMLElement, summary: ISummaryRenderer}]))
     );
 
     // reset summaries array


### PR DESCRIPTION
closes #258 

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [ ] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+

### Summary

fixes the bug that the header of a multilevel column isn't properly updated upon children change.  
