### PR TITLE
Switch order of `color` and `colorMapping` in `restoreColorMapping()`

### DIFF
--- a/src/model/ColorMappingFunction.ts
+++ b/src/model/ColorMappingFunction.ts
@@ -279,12 +279,12 @@ export function createColorMappingFunction(dump: any): IColorMappingFunction {
  * @internal
  */
 export function restoreColorMapping(desc: IMapAbleDesc): IColorMappingFunction {
-  if(desc.color) {
-    console.warn('The property `color` in the column description is deprecated and will not work in an upcoming LineUp release. Use the property `colorMapping` instead.');
-    return createColorMappingFunction(desc.color);
-  }
   if (desc.colorMapping) {
     return createColorMappingFunction(desc.colorMapping);
+  }
+  if (desc.color) {
+    console.warn('The property `color` in the column description is deprecated and will not work in an upcoming LineUp release. Use the property `colorMapping` instead.');
+    return createColorMappingFunction(desc.color);
   }
   return DEFAULT_COLOR_FUNCTION;
 }


### PR DESCRIPTION
**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [ ] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary

If both properties `color` and `colorMapping` are set in the column description, LineUp will use the `color` property instead of `colorMapping`. We need to switch the order, so that `colorMapping` has a higher priority and `color` is the backup (as it is deprecated).