### PR TITLE
Remove warning message by using `colorMapping` property in `deriveColors()` 

### DIFF
--- a/src/provider/utils.ts
+++ b/src/provider/utils.ts
@@ -121,7 +121,7 @@ export function deriveColors(columns: IColumnDesc[]) {
   columns.forEach((col: any) => {
     switch (col.type) {
       case 'number':
-        col.color = col.color || colors() || Column.DEFAULT_COLOR;
+        col.colorMapping = col.colorMapping || col.color || colors() || Column.DEFAULT_COLOR;
         break;
     }
   });


### PR DESCRIPTION
**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [ ] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
 
This commit is a backport of the LineUp v4 functionality. With the current implementation `deriveColors()` is using the deprecated `color` property, which prints a warning message. Switching to `colorMapping` resolves the problem.