### PR TITLE
Fix reset of the filter histogram

### DIFF
--- a/src/ui/dialogs/NumberFilterDialog.ts
+++ b/src/ui/dialogs/NumberFilterDialog.ts
@@ -7,7 +7,7 @@ import ADialog, {IDialogContext} from './ADialog';
 /** @internal */
 export default class NumberFilterDialog extends ADialog {
   private readonly before: INumberFilter;
-  private handler: {reset: () => void, submit: () => void} | null = null;
+  private handler: {reset: () => void, submit: () => void, cleanUp: () => void} | null = null;
 
   constructor(private readonly column: IMapAbleColumn, dialog: IDialogContext, private readonly ctx: IRankingHeaderContext) {
     super(dialog, {
@@ -23,8 +23,13 @@ export default class NumberFilterDialog extends ADialog {
     this.handler = createNumberFilter(this.column, node, {
       dialogManager: this.ctx.dialogManager,
       idPrefix: this.ctx.idPrefix,
-      tasks: this.ctx.provider.getTaskExecutor()
+      tasks: this.ctx.provider.getTaskExecutor(),
     }, this.showLivePreviews());
+  }
+
+  cleanUp(action: 'cancel' | 'confirm' | 'handled') {
+    super.cleanUp(action);
+    this.handler!.cleanUp();
   }
 
   protected reset() {


### PR DESCRIPTION
closes #282

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [ ] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
 
re renders the number filter histogram in case of the order changed = filter was successfully applied or reset