### PR TITLE
Renderer update after dirty caches (fix domain in histogram)

### DIFF
--- a/src/renderer/DateHistogramCellRenderer.ts
+++ b/src/renderer/DateHistogramCellRenderer.ts
@@ -238,7 +238,8 @@ function createFilterInfo(col: IDateColumn, domain: [number, number], filter = c
 }
 
 function createFilterContext(col: IDateColumn, context: {idPrefix: string, dialogManager: DialogManager}, domain: [number, number]): IFilterContext<number> {
-  const percent = (v: number) => Math.round(100 * (v - domain[0]) / (domain[1] - domain[0]));
+  const clamp = (v: number) => Math.max(0, Math.min(100, v));
+  const percent = (v: number) => clamp(Math.round(100 * (v - domain[0]) / (domain[1] - domain[0])));
   const unpercent = (v: number) => ((v / 100) * (domain[1] - domain[0]) + domain[0]);
   return {
     percent,

--- a/src/renderer/HistogramCellRenderer.ts
+++ b/src/renderer/HistogramCellRenderer.ts
@@ -217,7 +217,8 @@ function createFilterInfo(col: IMapAbleColumn, filter = col.getFilter()): IFilte
 function createFilterContext(col: IMapAbleColumn, context: {idPrefix: string, dialogManager: DialogManager}): IFilterContext<number> {
   const domain = col.getMapping().domain;
   const format = col.getNumberFormat();
-  const percent = (v: number) => Math.round(100 * (v - domain[0]) / (domain[1] - domain[0]));
+  const clamp = (v: number) => Math.max(0, Math.min(100, v));
+  const percent = (v: number) => clamp(Math.round(100 * (v - domain[0]) / (domain[1] - domain[0])));
   const unpercent = (v: number) => ((v / 100) * (domain[1] - domain[0]) + domain[0]);
   return {
     percent,

--- a/src/ui/EngineRanking.ts
+++ b/src/ui/EngineRanking.ts
@@ -1,7 +1,7 @@
 import {ACellTableSection, GridStyleManager, IAbortAblePromise, ICellRenderContext, IExceptionContext, isAbortAble, isAsyncUpdate, isLoadingCell, ITableSection, nonUniformContext, PrefetchMixin, tableIds, uniformContext, IAsyncUpdate} from 'lineupengine';
 import {ILineUpFlags} from '../config';
 import {HOVER_DELAY_SHOW_DETAIL} from '../constants';
-import {AEventDispatcher, clear, debounce, IEventContext, IEventHandler, IEventListener} from '../internal';
+import {AEventDispatcher, clear, debounce, IEventContext, IEventHandler, IEventListener, suffix} from '../internal';
 import {Column, IGroupData, IGroupItem, IOrderedGroup, isGroup, isMultiLevelColumn, Ranking, StackColumn, IGroupParent, defaultGroup, IGroup} from '../model';
 import {IImposer, IRenderCallback, IRenderContext} from '../renderer';
 import {CANVAS_HEIGHT, COLUMN_PADDING, cssClass, engineCssClass} from '../styles';
@@ -1083,7 +1083,7 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
         EngineRanking.disableListener(c); // destroy myself
       }
     });
-    c.on(`${Column.EVENT_SUMMARY_RENDERER_TYPE_CHANGED}.body`, () => {
+    c.on(suffix('.body', Column.EVENT_SUMMARY_RENDERER_TYPE_CHANGED, Column.EVENT_DIRTY_CACHES), () => {
       // replace myself upon renderer type change
       col.renderers = this.ctx.createRenderer(c);
       const valid = this.updateHeaderOf(col.c);
@@ -1121,7 +1121,7 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
 
   private static disableListener(c: Column) {
     c.on(`${Column.EVENT_WIDTH_CHANGED}.body`, null);
-    c.on([`${Column.EVENT_RENDERER_TYPE_CHANGED}.body`, `${Column.EVENT_GROUP_RENDERER_TYPE_CHANGED}.body`, `${Column.EVENT_SUMMARY_RENDERER_TYPE_CHANGED}.body`, `${Column.EVENT_LABEL_CHANGED}.body`], null);
+    c.on(suffix('.body', Column.EVENT_RENDERER_TYPE_CHANGED, Column.EVENT_GROUP_RENDERER_TYPE_CHANGED, Column.EVENT_SUMMARY_RENDERER_TYPE_CHANGED, Column.EVENT_DIRTY_CACHES, Column.EVENT_LABEL_CHANGED), null);
     c.on(`${Ranking.EVENT_DIRTY_HEADER}.body`, null);
     c.on(`${Ranking.EVENT_DIRTY_VALUES}.body`, null);
 

--- a/src/ui/panel/SidePanelEntryVis.ts
+++ b/src/ui/panel/SidePanelEntryVis.ts
@@ -4,6 +4,7 @@ import {ISummaryRenderer} from '../../renderer';
 import {cssClass, engineCssClass} from '../../styles';
 import {createShortcutMenuItems, dragAbleColumn, updateHeader} from '../header';
 import {IRankingHeaderContext} from '../interfaces';
+import {suffix} from '../../internal';
 
 /** @internal */
 export default class SidePanelEntryVis {
@@ -19,10 +20,10 @@ export default class SidePanelEntryVis {
 
     this.summary = ctx.summaryRenderer(column, true);
 
-    this.column.on([`${NumberColumn.EVENT_FILTER_CHANGED}.panel`, `${Column.EVENT_DIRTY_HEADER}.panel`], () => {
+    this.column.on(suffix('.panel', NumberColumn.EVENT_FILTER_CHANGED, Column.EVENT_DIRTY_HEADER), () => {
       this.update();
     });
-    this.column.on(`${Column.EVENT_SUMMARY_RENDERER_TYPE_CHANGED}.panel`, () => {
+    this.column.on(suffix('.panel',Column.EVENT_SUMMARY_RENDERER_TYPE_CHANGED, Column.EVENT_DIRTY_CACHES), () => {
       this.recreateSummary();
     });
     this.init();
@@ -90,7 +91,7 @@ export default class SidePanelEntryVis {
   }
 
   destroy() {
-    this.column.on([`${NumberColumn.EVENT_FILTER_CHANGED}.panel`, `${Column.EVENT_DIRTY_HEADER}.panel`, `${Column.EVENT_SUMMARY_RENDERER_TYPE_CHANGED}.panel`], null);
+    this.column.on(suffix('.panel', NumberColumn.EVENT_FILTER_CHANGED, Column.EVENT_DIRTY_HEADER, Column.EVENT_SUMMARY_RENDERER_TYPE_CHANGED, Column.EVENT_DIRTY_CACHES), null);
     this.node.remove();
   }
 }


### PR DESCRIPTION
closes #314

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [ ] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
 
re tdp_core -> `column.markDirty()` should help