### PR TITLE
add more patterns to detect dates

### DIFF
--- a/demo/dates.html
+++ b/demo/dates.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+  <meta charset="UTF-8">
+  <title>LineUp Builder Test</title>
+
+  <link href="./LineUpJS.css" rel="stylesheet">
+  <link href="./demo.css" rel="stylesheet">
+</head>
+<body>
+<script src="https://d3js.org/d3.v4.min.js"></script>
+<script src="./LineUpJS.js"></script>
+
+<script>
+  window.onload = function () {
+    const arr = [];
+    const cats = ['c1', 'c2', 'c3'];
+    const f = d3.timeFormat('%x');
+    for (let i = 0; i < 100; ++i) {
+      const d = new Date(Date.now() - Math.floor(Math.random() * 1000000000000));
+      arr.push({
+        dateObj: d,
+        dateIso: d.toISOString(),
+        dateFormatted: f(d),
+        dateYYYYMMDD: `${d.getFullYear()}-${d.getMonth()+1}-${d.getDate()}`
+      });
+    }
+    const lineup = LineUpJS.asTaggle(document.body, arr);
+  };
+</script>
+
+</body>
+</html>

--- a/src/provider/interfaces.ts
+++ b/src/provider/interfaces.ts
@@ -145,7 +145,7 @@ export interface IDeriveOptions {
    * date pattern to check for string matching them
    * @default %x
    */
-  datePattern: string;
+  datePattern: string | string[];
 }
 
 

--- a/src/provider/utils.ts
+++ b/src/provider/utils.ts
@@ -51,11 +51,15 @@ function deriveBaseType(value: any, all: () => any[], column: number | string, o
     };
   }
 
-  const dateParse = timeParse(options.datePattern);
-  if (value instanceof Date || dateParse(value) != null) {
-    return {
-      type: 'date'
-    };
+  const formats = Array.isArray(options.datePattern) ? options.datePattern : [options.datePattern];
+  for (const format of formats) {
+    const dateParse = timeParse(format);
+    if (value instanceof Date || dateParse(value) != null) {
+      return {
+        type: 'date',
+        dateParse: format
+      };
+    }
   }
   const treatAsCategorical = typeof options.categoricalThreshold === 'function' ? options.categoricalThreshold : (u: number, t: number) => u < t * (<number>options.categoricalThreshold);
 
@@ -246,7 +250,7 @@ export function deriveColumnDescriptions(data: any[], options: Partial<IDeriveOp
   const config = Object.assign({
     categoricalThreshold: (u: number, n: number) => u <= MAX_COLORS && u < n * 0.7, //70% unique and less equal to 22 categories
     columns: [],
-    datePattern: '%x'
+    datePattern: ['%x', '%Y-%m-%d', '%Y-%m-%dT%H:%M:%S.%LZ']
   }, options);
 
   const r: IColumnDesc[] = [];

--- a/src/provider/utils.ts
+++ b/src/provider/utils.ts
@@ -51,15 +51,21 @@ function deriveBaseType(value: any, all: () => any[], column: number | string, o
     };
   }
 
+  if (value instanceof Date) {
+    return {
+      type: 'date'
+    };
+  }
   const formats = Array.isArray(options.datePattern) ? options.datePattern : [options.datePattern];
   for (const format of formats) {
     const dateParse = timeParse(format);
-    if (value instanceof Date || dateParse(value) != null) {
-      return {
-        type: 'date',
-        dateParse: format
-      };
+    if (dateParse(value) == null) {
+      continue;
     }
+    return {
+      type: 'date',
+      dateParse: format
+    };
   }
   const treatAsCategorical = typeof options.categoricalThreshold === 'function' ? options.categoricalThreshold : (u: number, t: number) => u < t * (<number>options.categoricalThreshold);
 


### PR DESCRIPTION
**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
 
adds more date patterns date are automatically detected including the most used iso format: 

```js
const f = d3.timeFormat('%x');
    for (let i = 0; i < 100; ++i) {
      const d = new Date(Date.now() - Math.floor(Math.random() * 1000000000000));
      arr.push({
        dateObj: d,
        dateIso: d.toISOString(),
        dateFormatted: f(d),
        dateYYYYMMDD: `${d.getFullYear()}-${d.getMonth()+1}-${d.getDate()}`
      });
    }
```

all 4 formats are now detected as dates
