### PR TITLE
Clear filter when string column filter is null and filterMissing: false

### DIFF
--- a/src/renderer/StringCellRenderer.ts
+++ b/src/renderer/StringCellRenderer.ts
@@ -65,7 +65,8 @@ export default class StringCellRenderer implements ICellRendererFactory {
     const update = () => {
       const valid = input.value.trim();
       if (valid.length <= 0) {
-        col.setFilter({filter: null, filterMissing: filterMissing.checked});
+        const filter = filterMissing.checked ? {filter: null, filterMissing: filterMissing.checked} : null;
+        col.setFilter(filter);
         return;
       }
       col.setFilter({


### PR DESCRIPTION
Closes datavisyn/tdp_core#374


**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
 
* Added check in `StringCellRenderer.ts` to convert `{filter:null, filterMissing:False}` to `null `. In other words clear the filter the way we do in `StringFilterDialog`
https://github.com/lineupjs/lineupjs/blob/a3e0b8cd01f41f49c6f1ef991c6497074dc0c462/src/ui/dialogs/StringFilterDialog.ts#L31-L32

Another solution would also be to disable the filterMissing checkbox (as is the case for the categorical and number columns) which would also fix the bug but might require more time implementing.
The result:

![clear_string_filter](https://user-images.githubusercontent.com/51322092/84151721-0d9bfe80-aa64-11ea-84a9-cb2512251d7a.gif)
