### PR TITLE
Add new lines between checkbox and text for equal spacing

### DIFF
--- a/src/renderer/StringCellRenderer.ts
+++ b/src/renderer/StringCellRenderer.ts
@@ -110,7 +110,10 @@ export default class StringCellRenderer implements ICellRendererFactory {
     let update: (col: StringColumn) => void;
     return {
       template: `<form><input type="text" placeholder="Filter ${col.desc.label}..." autofocus value="${(bak instanceof RegExp) ? bak.source : bak}">
-          <label class="${cssClass('checkbox')}"><input type="checkbox" ${(bak instanceof RegExp) ? 'checked="checked"' : ''}><span>Use regular expressions</span></label>
+          <label class="${cssClass('checkbox')}">
+            <input type="checkbox" ${(bak instanceof RegExp) ? 'checked="checked"' : ''}>
+            <span>Use regular expressions</span>
+          </label>
           ${filterMissingMarkup(f.filterMissing)}</form>`,
       update: (node: HTMLElement) => {
         if (!update) {

--- a/src/ui/dialogs/SearchDialog.ts
+++ b/src/ui/dialogs/SearchDialog.ts
@@ -14,7 +14,12 @@ export default class SearchDialog extends ADialog {
   }
 
   protected build(node: HTMLElement) {
-    node.insertAdjacentHTML('beforeend', `<input type="text" size="20" value="" required autofocus placeholder="search... (>= 3 chars)"><label class="${cssClass('checkbox')}"><input type="checkbox"><span>Use regular expressions</span></label>`);
+    node.insertAdjacentHTML('beforeend', `<input type="text" size="20" value="" required autofocus placeholder="search... (>= 3 chars)">
+      <label class="${cssClass('checkbox')}">
+        <input type="checkbox">
+        <span>Use regular expressions</span>
+      </label>
+    `);
 
     const input = <HTMLInputElement>node.querySelector('input[type="text"]')!;
     const checkbox = <HTMLInputElement>node.querySelector('input[type="checkbox"]')!;

--- a/src/ui/dialogs/StringFilterDialog.ts
+++ b/src/ui/dialogs/StringFilterDialog.ts
@@ -59,7 +59,10 @@ export default class StringFilterDialog extends ADialog {
   protected build(node: HTMLElement) {
     const bak = this.column.getFilter() || {filter: '', filterMissing: false};
     node.insertAdjacentHTML('beforeend', `<input type="text" placeholder="Filter ${this.column.desc.label}..." autofocus value="${(bak.filter instanceof RegExp) ? bak.filter.source : bak.filter || ''}" style="width: 100%">
-    <label class="${cssClass('checkbox')}"><input type="checkbox" ${(bak.filter instanceof RegExp) ? 'checked="checked"' : ''}><span>Use regular expressions</span></label>
+    <label class="${cssClass('checkbox')}">
+      <input type="checkbox" ${(bak.filter instanceof RegExp) ? 'checked="checked"' : ''}>
+      <span>Use regular expressions</span>
+    </label>
     ${filterMissingMarkup(bak.filterMissing)}`);
 
     const filterMissing = findFilterMissing(node);


### PR DESCRIPTION
**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [ ] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary

Prevent different spacings for `Use regular expression` and `Filter missing values`.

**Before**
![grafik](https://user-images.githubusercontent.com/5851088/84173334-6fb52d80-aa7d-11ea-9b0d-549721942a74.png)

**After**
![grafik](https://user-images.githubusercontent.com/5851088/84173397-88bdde80-aa7d-11ea-8390-c3c69af19e7b.png)

