### PR TITLE
Unify font style + size for checkboxes in dialogs

### DIFF
--- a/src/styles/_common.scss
+++ b/src/styles/_common.scss
@@ -24,10 +24,6 @@
   }
 }
 
-.#{$lu_css_prefix}-filter-missing {
-  font-size: 13px;
-}
-
 .#{$lu_css_prefix}-checkbox {
   display: inline;
 

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -63,7 +63,7 @@
     font-size: 8pt;
   }
 
-  .#{$lu_css_prefix}-checkbox > span {
+  .#{$lu_css_prefix}-checkbox:not(.#{$lu_css_prefix}-dialog-filter-table-entry) > span {
     font-weight: normal;
     align-items: center;
     margin: 5px 0;

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -62,6 +62,13 @@
   input {
     font-size: 8pt;
   }
+  
+  .#{$lu_css_prefix}-checkbox > span {
+    font-weight: normal;
+    align-items: center;
+    margin: 5px 0;
+    font-size: 13px;
+  }
 }
 
 .#{$lu_css_prefix}-dialog-button {

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -62,7 +62,7 @@
   input {
     font-size: 8pt;
   }
-  
+
   .#{$lu_css_prefix}-checkbox > span {
     font-weight: normal;
     align-items: center;


### PR DESCRIPTION
**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [ ] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
 
**Before**

![grafik](https://user-images.githubusercontent.com/5851088/84174947-89f00b00-aa7f-11ea-9675-30445e35e4ce.png)


**After**

![grafik](https://user-images.githubusercontent.com/5851088/84174850-662cc500-aa7f-11ea-8d1c-a7a83097b059.png)


Spacing between checkbox and label is adressed in PR #342.
