### PR TITLE
Replace `overflow-x` with `overflow` to avoid scrollbars in stacked bars

### DIFF
--- a/src/renderer/MultiLevelCellRenderer.ts
+++ b/src/renderer/MultiLevelCellRenderer.ts
@@ -121,7 +121,7 @@ export default class MultiLevelCellRenderer extends AAggregatedGroupRenderer<IMu
             if (ci < cols.length - 1) {
               const span = cnode.querySelector('span');
               if (span) {
-                span.style.overflowX = 'hidden';
+                span.style.overflow = 'hidden';
               }
             }
           }


### PR DESCRIPTION
Closes #344

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [ ] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
 
Fix scrollbar caused by `overflow-x`

![grafik](https://user-images.githubusercontent.com/5851088/84172303-26b0a980-aa7c-11ea-884e-dd3afaf78b8c.png)
