### PR TITLE
Minor modification to the AggregateGroupRenderer summary implementation

### DIFF
--- a/src/provider/ADataProvider.ts
+++ b/src/provider/ADataProvider.ts
@@ -811,12 +811,15 @@ abstract class ADataProvider extends AEventDispatcher implements IDataProvider {
       v = aggregateAll;
     }
 
+    const changed: IOrderedGroup[] = [];
+
     for(const group of groups) {
       this.unaggregateParents(ranking, group);
       const current = this.getTopNAggregated(ranking, group);
       if (current === v) {
         continue;
       }
+      changed.push(group);
       const key = `${ranking.id}@${toGroupID(group)}`;
       if (v >= 0) {
         this.aggregations.set(key, v);
@@ -824,7 +827,7 @@ abstract class ADataProvider extends AEventDispatcher implements IDataProvider {
         this.aggregations.delete(key);
       }
     }
-    this.fire([ADataProvider.EVENT_GROUP_AGGREGATION_CHANGED, ADataProvider.EVENT_DIRTY_VALUES, ADataProvider.EVENT_DIRTY], ranking, groups, v >= 0, v);
+    this.fire([ADataProvider.EVENT_GROUP_AGGREGATION_CHANGED, ADataProvider.EVENT_DIRTY_VALUES, ADataProvider.EVENT_DIRTY], ranking, changed, v >= 0, v);
   }
 
   getShowTopN() {

--- a/src/renderer/AggregateGroupRenderer.ts
+++ b/src/renderer/AggregateGroupRenderer.ts
@@ -192,14 +192,16 @@ export default class AggregateGroupRenderer implements ICellRendererFactory {
         for (let i = 0; i < max; ++i) {
           const child = children[i];
           const subGroups = <IOrderedGroup[]>gparents.map((d) => d[i] ? d[i].group : null).filter((d) => d != null);
-
           const isCollapsed = subGroups.every((d) => context.provider.getAggregationState(ranking, d) === EAggregationState.COLLAPSE);
+
+          const action = isCollapsed ? EAggregationState.EXPAND : EAggregationState.COLLAPSE;
+          const targetSubGroups = subGroups.filter((g) => context.provider.getAggregationState(ranking, g) !== action);
+
           child.classList.toggle(cssClass('agg-collapse'), isCollapsed);
           child.title = isCollapsed ? 'Expand All Groups' : 'Collapse All Groups';
-
           child.onclick = (evt) => {
             preventDefault(evt);
-            context.provider.aggregateAllOf(ranking, isCollapsed ? EAggregationState.EXPAND : EAggregationState.COLLAPSE, subGroups);
+            context.provider.aggregateAllOf(ranking, action, targetSubGroups);
           };
         }
       }

--- a/src/renderer/AggregateGroupRenderer.ts
+++ b/src/renderer/AggregateGroupRenderer.ts
@@ -192,6 +192,7 @@ export default class AggregateGroupRenderer implements ICellRendererFactory {
         for (let i = 0; i < max; ++i) {
           const child = children[i];
           const subGroups = <IOrderedGroup[]>gparents.map((d) => d[i] ? d[i].group : null).filter((d) => d != null);
+
           const isCollapsed = subGroups.every((d) => context.provider.getAggregationState(ranking, d) === EAggregationState.COLLAPSE);
 
           const action = isCollapsed ? EAggregationState.EXPAND : EAggregationState.COLLAPSE;
@@ -199,6 +200,7 @@ export default class AggregateGroupRenderer implements ICellRendererFactory {
 
           child.classList.toggle(cssClass('agg-collapse'), isCollapsed);
           child.title = isCollapsed ? 'Expand All Groups' : 'Collapse All Groups';
+
           child.onclick = (evt) => {
             preventDefault(evt);
             context.provider.aggregateAllOf(ranking, action, targetSubGroups);

--- a/src/renderer/AggregateGroupRenderer.ts
+++ b/src/renderer/AggregateGroupRenderer.ts
@@ -195,15 +195,12 @@ export default class AggregateGroupRenderer implements ICellRendererFactory {
 
           const isCollapsed = subGroups.every((d) => context.provider.getAggregationState(ranking, d) === EAggregationState.COLLAPSE);
 
-          const action = isCollapsed ? EAggregationState.EXPAND : EAggregationState.COLLAPSE;
-          const targetSubGroups = subGroups.filter((g) => context.provider.getAggregationState(ranking, g) !== action);
-
           child.classList.toggle(cssClass('agg-collapse'), isCollapsed);
           child.title = isCollapsed ? 'Expand All Groups' : 'Collapse All Groups';
 
           child.onclick = (evt) => {
             preventDefault(evt);
-            context.provider.aggregateAllOf(ranking, action, targetSubGroups);
+            context.provider.aggregateAllOf(ranking, isCollapsed ? EAggregationState.EXPAND : EAggregationState.COLLAPSE, subGroups);
           };
         }
       }


### PR DESCRIPTION
Complements datavisyn/tdp_core#378

**Prerequisites**:

* [x] Branch is up-to-date with the branch to be merged with, i.e. develop
* [x] Build is successful
* [x] Code is cleaned up and formatted 
* [x] Tested with Firefox ESR, latest Firefox, latest Chrome, Edge 18


### Summary
 When `collapsing/uncollapsing` all groups in the `AggregateGroupColumn` we fire the event 
`ADataProvider.EVENT_GROUP_AGGREGATION_CHANGED` and pass all groups to the callback.

In order to be able to track the aggregation state in `tdp_core` we need to know which groups were `collapsed/expanded` before the event was triggered.

With this PR instead of passing all groups to the event callback, we only pass the groups that have an opposite aggregation state to the one being currently triggered.