### PR TITLE
Fix a test race condition

### DIFF
--- a/cypress/integration/utils/ui.ts
+++ b/cypress/integration/utils/ui.ts
@@ -1,5 +1,5 @@
 export function aggregateAll() {
-  cy.get('.lu-summary .lu-agg-expand').first().click();
+  cy.get('.lu-summary .lu-agg-expand').first().click().wait(200);
 }
 
 export function closeDialog(action: 'cancel' | 'confirm' = 'confirm') {

--- a/cypress/integration/utils/ui.ts
+++ b/cypress/integration/utils/ui.ts
@@ -1,5 +1,5 @@
 export function aggregateAll() {
-  cy.get('.lu-summary .lu-agg-expand').first().click().wait(200);
+  cy.get('.lu-summary .lu-agg-expand').first().wait(200).click();
 }
 
 export function closeDialog(action: 'cancel' | 'confirm' = 'confirm') {


### PR DESCRIPTION

**Prerequisites**:

* [x] Branch is up-to-date with the branch to be merged with, i.e. develop
* [x] Build is successful
* [x] Code is cleaned up and formatted 
* [ ] Tested with Firefox ESR, latest Firefox, latest Chrome, Edge 18


### Summary
 
fix a race animation condition in a test while aggregating all groups