### PR TITLE
Changed getDay() to getDate() in date histogram computation

### DIFF
--- a/src/internal/math.ts
+++ b/src/internal/math.ts
@@ -408,7 +408,7 @@ function computeGranularity(min: Date | null, max: Date | null): {histGranularit
 
   if ((max.getTime() - min.getTime()) <= 1000 * 60 * 60 * 24 * 31) {
     // less than a month use day
-    let x0 = new Date(min.getFullYear(), min.getMonth(), min.getDay());
+    let x0 = new Date(min.getFullYear(), min.getMonth(), min.getDate());
     while (x0 <= max) {
       const x1 = new Date(x0);
       x1.setDate(x1.getDate() + 1);


### PR DESCRIPTION
Closes #379 

**Prerequisites**:

* [x] Branch is up-to-date with the branch to be merged with, i.e. develop
* [ ] Build is successful
* [x] Code is cleaned up and formatted 
* [x] Tested with Firefox ESR, latest Firefox, latest Chrome, Edge 18


### Summary
Javascript is weird because `getDay()` does not return what you think it does. See #379 for more information.