### PR TITLE
Update colors for boolean values in BooleanColumn

### DIFF
--- a/src/model/BooleanColumn.ts
+++ b/src/model/BooleanColumn.ts
@@ -48,8 +48,8 @@ export default class BooleanColumn extends ValueColumn<boolean> implements ICate
   static readonly EVENT_FILTER_CHANGED = 'filterChanged';
   static readonly EVENT_COLOR_MAPPING_CHANGED = 'colorMappingChanged';
 
-  static readonly GROUP_TRUE = {name: 'True', color: 'black'};
-  static readonly GROUP_FALSE = {name: 'False', color: 'white'};
+  static readonly GROUP_TRUE = {name: 'True', color: '#444444'};
+  static readonly GROUP_FALSE = {name: 'False', color: '#eeeeee'};
 
   private currentFilter: ICategoricalFilter | null = null;
 


### PR DESCRIPTION
**Prerequisites**:

* [x] Branch is up-to-date with the branch to be merged with, i.e. develop
* [x] Build is successful
* [x] Code is cleaned up and formatted 
* [x] Tested with Firefox ESR, latest Firefox, latest Chrome, Edge 18


### Summary

The white for `false` values was not visible and looked like a rendering issue and the black for `true` values had a strong contrast. This commit de-emphasizes the colors.


**Before**

![grafik](https://user-images.githubusercontent.com/5851088/89684590-0c1f7300-d8fb-11ea-8e05-7414e4690a3d.png)

**After** 

![grafik](https://user-images.githubusercontent.com/5851088/89763170-44d56d00-daf2-11ea-80d7-bc7e1cc44cae.png)
