### PR TITLE
BooleanColumn: Switch default renderer to categorical renderer

### DIFF
--- a/src/model/BooleanColumn.ts
+++ b/src/model/BooleanColumn.ts
@@ -49,7 +49,7 @@ export default class BooleanColumn extends ValueColumn<boolean> implements ICate
   static readonly EVENT_COLOR_MAPPING_CHANGED = 'colorMappingChanged';
 
   static readonly GROUP_TRUE = {name: 'True', color: '#444444'};
-  static readonly GROUP_FALSE = {name: 'False', color: '#eeeeee'};
+  static readonly GROUP_FALSE = {name: 'False', color: '#dddddd'};
 
   private currentFilter: ICategoricalFilter | null = null;
 
@@ -59,6 +59,7 @@ export default class BooleanColumn extends ValueColumn<boolean> implements ICate
   constructor(id: string, desc: Readonly<IBooleanColumnDesc>) {
     super(id, integrateDefaults(desc, {
       width: 30,
+      renderer: 'categorical',
       groupRenderer: 'categorical',
       summaryRenderer: 'categorical'
     }));


### PR DESCRIPTION
**Prerequisites**:

* [x] Branch is up-to-date with the branch to be merged with, i.e. develop
* [x] Build is successful
* [x] Code is cleaned up and formatted 
* [x] Tested with Firefox ESR, latest Firefox, latest Chrome, Edge 18


### Summary

Another minor change to the `False` color and switch the default renderer to the categorical renderer.

**Before**

![grafik](https://user-images.githubusercontent.com/5851088/89880720-d7ded780-dbc4-11ea-8240-a3cd15f6f8ee.png)

**After**

![grafik](https://user-images.githubusercontent.com/5851088/89880760-e5945d00-dbc4-11ea-9663-3fb889174d61.png)

