### PR TITLE
Add `filterAccuracy` property to `INumberDesc`

### DIFF
--- a/demo/small_numbers.html
+++ b/demo/small_numbers.html
@@ -68,7 +68,8 @@
           .label('Column with small numbers')
           .width(250)
           .mapping('log', [minN, maxN], [1, 0])
-          .custom('numberFormat', 'e'),
+          .custom('numberFormat', 'e')
+          .custom('filterAccuracy', 0.00001),
       );
 
 

--- a/src/model/INumberColumn.ts
+++ b/src/model/INumberColumn.ts
@@ -107,6 +107,13 @@ export interface INumberDesc extends IMapAbleDesc {
    * @default .3n
    */
   numberFormat?: string;
+
+  /**
+   * The accuracy defines the deviation of values to the applied filter boundary.
+   * Use an accuracy closer to 0 for columns with smaller numbers (e.g., 1e-9).
+   * @default 0.001
+   */
+  filterAccuracy?: number;
 }
 
 /**

--- a/src/model/NumberColumn.ts
+++ b/src/model/NumberColumn.ts
@@ -69,10 +69,16 @@ export default class NumberColumn extends ValueColumn<number> implements INumber
 
   /**
    * currently active filter
-   * @type {{min: number, max: number}}
    * @private
    */
   private currentFilter: INumberFilter = noNumberFilter();
+
+  /**
+   * The accuracy defines the deviation of values to the applied filter boundary.
+   * Use an accuracy closer to 0 for columns with smaller numbers (e.g., 1e-9).
+   * @private
+   */
+  private readonly filterAccuracy: number = 0.001;
 
   private readonly numberFormat: (n: number) => string = format('.2f');
 
@@ -91,6 +97,10 @@ export default class NumberColumn extends ValueColumn<number> implements INumber
 
     if (desc.numberFormat) {
       this.numberFormat = format(desc.numberFormat);
+    }
+
+    if (desc.filterAccuracy) {
+      this.filterAccuracy = desc.filterAccuracy;
     }
   }
 
@@ -281,7 +291,7 @@ export default class NumberColumn extends ValueColumn<number> implements INumber
 
   setFilter(value: INumberFilter | null) {
     value = value || {min: -Infinity, max: +Infinity, filterMissing: false};
-    if (isEqualNumberFilter(value, this.currentFilter)) {
+    if (isEqualNumberFilter(value, this.currentFilter, this.filterAccuracy)) {
       return;
     }
     const bak = this.getFilter();

--- a/src/model/internalNumber.ts
+++ b/src/model/internalNumber.ts
@@ -60,8 +60,8 @@ export function noNumberFilter() {
 }
 
 /** @internal */
-export function isEqualNumberFilter(a: INumberFilter, b: INumberFilter) {
-  return similar(a.min, b.min, 0.001) && similar(a.max, b.max, 0.001) && a.filterMissing === b.filterMissing;
+export function isEqualNumberFilter(a: INumberFilter, b: INumberFilter, delta = 0.001) {
+  return similar(a.min, b.min, delta) && similar(a.max, b.max, delta) && a.filterMissing === b.filterMissing;
 }
 
 /** @internal */


### PR DESCRIPTION
Related to #188 + #189.

**Prerequisites**:

* [x] Branch is up-to-date with the branch to be merged with, i.e. develop
* [x] Build is successful
* [x] Code is cleaned up and formatted 
* [ ] Tested with Firefox ESR, latest Firefox, latest Chrome, Edge 18


### Summary

This PR adds a `filterAccuracy` property to `INumberDesc`, which is used as `delta` to compare the row values with the applied filter. This option allows to use smaller delta when using very small numbers (e.g., 1e-9). The default value remains `0.001`.