### PR TITLE
Fix derive column type for dataset properties with `[]` or `null`

### DIFF
--- a/src/provider/utils.ts
+++ b/src/provider/utils.ts
@@ -190,7 +190,7 @@ function deriveType(label: string, value: any, column: number | string, all: () 
 
   // check boxplot
   const bs = ['min', 'max', 'median', 'q1', 'q3'];
-  if (typeof value === 'object' && bs.every((b) => typeof value[b] === 'number')) {
+  if (value !== null && typeof value === 'object' && bs.every((b) => typeof value[b] === 'number')) {
     //  boxplot
     const vs = all();
     return Object.assign(base, {
@@ -202,7 +202,7 @@ function deriveType(label: string, value: any, column: number | string, all: () 
     });
   }
 
-  if (typeof value === 'object') {
+  if (value !== null && typeof value === 'object') {
     // object map
     const first = Object.keys(value).map((k) => value[k]).filter((d) => !isEmpty(d));
     const mapAll = () => {


### PR DESCRIPTION
Fixes #399

**Prerequisites**:

* [x] Branch is up-to-date with the branch to be merged with, i.e. develop
* [x] Build is successful
* [x] Code is cleaned up and formatted 
* [ ] Tested with Firefox ESR, latest Firefox, latest Chrome, Edge 18


### Summary

Previously, deriving the column type was broken for dataset properties containing `[]` or `null`. This fix skips the boxplot and object map detection for `null` values. 

In both cases the column is rendered and the cells contain missing values:

![grafik](https://user-images.githubusercontent.com/5851088/100080929-b8537e00-2e46-11eb-84e9-b708a4cc080d.png)

In addition, the console logs the following output:

![grafik](https://user-images.githubusercontent.com/5851088/100080994-cb664e00-2e46-11eb-870b-0753b1d5f161.png)

 
