### PR TITLE
show raw histogram in side panel

### DIFF
--- a/demo/big.html
+++ b/demo/big.html
@@ -22,7 +22,7 @@
           arr.push({
             label: 'Row ' + i,
             number: Math.random() * 10,
-            number2: Math.random() * 10,
+            number2: Math.random() * 10 * (Math.random() < 0.4 ? 0.5 : 1),
             cat: cats[Math.floor(Math.random() * cats.length)],
             cat2: cat2[Math.floor(Math.random() * cat2.length)],
             date: new Date(Date.now() - Math.floor(Math.random() * 1000000000000)),
@@ -46,6 +46,7 @@
             type: 'number',
             column: 'number2',
             domain: [0, 10],
+            range: [1, 0],
           },
           {
             label: 'Cat',

--- a/demo/invert_mapping.html
+++ b/demo/invert_mapping.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head lang="en">
+    <meta charset="UTF-8" />
+    <title>LineUp Builder Test</title>
+
+    <link href="./LineUpJS.css" rel="stylesheet" />
+    <link href="./demo.css" rel="stylesheet" />
+  </head>
+  <body>
+    <script src="./LineUpJS.js"></script>
+
+    <script>
+      window.onload = function () {
+        const arr = [];
+        const cats = ['c1', 'c2', 'c3'];
+        for (let i = 0; i < 100; ++i) {
+          arr.push({
+            a: Math.random() * 10 * (Math.random() < 0.4 ? 0.3 : 1),
+            d: 'Row ' + i,
+            cat: cats[Math.floor(Math.random() * 3)],
+            cat2: cats[Math.floor(Math.random() * 3)],
+          });
+        }
+        const builder = LineUpJS.builder(arr);
+        builder.deriveColumns(['-a']).column(LineUpJS.buildNumberColumn('a').mapping('linear', [0, 10], [1, 0]));
+        builder.buildTaggle(document.body);
+      };
+    </script>
+  </body>
+</html>

--- a/src/internal/math.ts
+++ b/src/internal/math.ts
@@ -300,11 +300,12 @@ export function boxplotBuilder(
 /**
  * @internal
  */
-export function normalizedStatsBuilder(numberOfBins: number): IBuilder<number, IStatistics> {
+export function numberStatsBuilder(domain: [number, number], numberOfBins: number): IBuilder<number, IStatistics> {
   const hist: INumberBin[] = [];
 
-  let x0 = 0;
-  const binWidth = 1 / numberOfBins;
+  let x0 = domain[0];
+  const range = domain[1] - domain[0];
+  const binWidth = range / numberOfBins;
   for (let i = 0; i < numberOfBins; ++i, x0 += binWidth) {
     hist.push({
       x0,
@@ -313,8 +314,8 @@ export function normalizedStatsBuilder(numberOfBins: number): IBuilder<number, I
     });
   }
 
-  const bin1 = 0 + binWidth;
-  const binN = 1 - binWidth;
+  const bin1 = domain[0] + binWidth;
+  const binN = domain[1] - binWidth;
 
   const toBin = (v: number) => {
     if (v < bin1) {
@@ -860,6 +861,7 @@ export interface INumberStatsMessageRequest {
   refData: string;
   data?: Float32Array;
 
+  domain: [number, number];
   numberOfBins: number;
 }
 
@@ -1075,7 +1077,7 @@ function sortWorkerMain() {
   const numberStats = (r: INumberStatsMessageRequest) => {
     const { data, indices } = resolveRefs<Float32Array>(r);
 
-    const b = normalizedStatsBuilder(r.numberOfBins);
+    const b = numberStatsBuilder(r.domain ?? [0, 1], r.numberOfBins);
 
     if (indices) {
       // tslint:disable-next-line:prefer-for-of
@@ -1151,7 +1153,7 @@ export function createWorkerBlob() {
   return createWorkerCodeBlob([
     pushAll.toString(),
     quantile.toString(),
-    normalizedStatsBuilder.toString(),
+    numberStatsBuilder.toString(),
     boxplotBuilder.toString(),
     computeGranularity.toString(),
     pushDateHist.toString(),

--- a/src/provider/DirectRenderTasks.ts
+++ b/src/provider/DirectRenderTasks.ts
@@ -151,9 +151,7 @@ export class DirectRenderTasks extends ARenderTasks implements IRenderTaskExecut
   groupNumberStats(col: Column & INumberColumn, group: IOrderedGroup, raw?: boolean) {
     const { summary, data } = this.summaryNumberStatsD(col, raw);
     return taskNow({
-      group: this.normalizedStatsBuilder(group.order, col, summary.hist.length, raw).next(
-        Number.POSITIVE_INFINITY as any
-      ).value!,
+      group: this.statsBuilder(group.order, col, summary.hist.length, raw).next(Number.POSITIVE_INFINITY as any).value!,
       summary,
       data,
     });
@@ -201,9 +199,7 @@ export class DirectRenderTasks extends ARenderTasks implements IRenderTaskExecut
         const ranking = col.findMyRanker()!.getOrder();
         const data = this.dataNumberStats(col, raw);
         return {
-          summary: this.normalizedStatsBuilder(ranking, col, data.hist.length, raw).next(
-            Number.POSITIVE_INFINITY as any
-          ).value!,
+          summary: this.statsBuilder(ranking, col, data.hist.length, raw).next(Number.POSITIVE_INFINITY as any).value!,
           data,
         };
       },
@@ -286,9 +282,8 @@ export class DirectRenderTasks extends ARenderTasks implements IRenderTaskExecut
       'data',
       col,
       () =>
-        this.normalizedStatsBuilder(null, col, getNumberOfBins(this.data.length), raw).next(
-          Number.POSITIVE_INFINITY as any
-        ).value!,
+        this.statsBuilder(null, col, getNumberOfBins(this.data.length), raw).next(Number.POSITIVE_INFINITY as any)
+          .value!,
       raw ? ':raw' : ''
     );
   }

--- a/src/provider/ScheduledTasks.ts
+++ b/src/provider/ScheduledTasks.ts
@@ -347,7 +347,7 @@ export class ScheduleRenderTasks extends ARenderTasks implements IRenderTaskExec
             this.workers
               .pushStats(
                 'numberStats',
-                { numberOfBins: summary.hist.length },
+                { numberOfBins: summary.hist.length, domain: this.resolveDomain(col, raw) },
                 key,
                 this.valueCacheData.get(key) as Float32Array,
                 `${ranking.id}:${group.name}`,
@@ -355,7 +355,7 @@ export class ScheduleRenderTasks extends ARenderTasks implements IRenderTaskExec
               )
               .then((group) => ({ group, summary, data }));
         }
-        return this.normalizedStatsBuilder(group.order, col, summary.hist.length, raw, (group) => ({
+        return this.statsBuilder(group.order, col, summary.hist.length, raw, (group) => ({
           group,
           summary,
           data,
@@ -439,7 +439,7 @@ export class ScheduleRenderTasks extends ARenderTasks implements IRenderTaskExec
           this.workers
             .pushStats(
               'numberStats',
-              { numberOfBins: data.hist.length },
+              { numberOfBins: data.hist.length, domain: this.resolveDomain(col, raw) },
               key,
               this.valueCacheData.get(key) as Float32Array,
               ranking.id,
@@ -447,7 +447,7 @@ export class ScheduleRenderTasks extends ARenderTasks implements IRenderTaskExec
             )
             .then((summary) => ({ summary, data }));
       }
-      return this.normalizedStatsBuilder(order ? order : ranking.getOrder(), col, data.hist.length, raw, (summary) => ({
+      return this.statsBuilder(order ? order : ranking.getOrder(), col, data.hist.length, raw, (summary) => ({
         summary,
         data,
       }));
@@ -630,7 +630,7 @@ export class ScheduleRenderTasks extends ARenderTasks implements IRenderTaskExec
     return this.cached(
       `${col.id}:c:data${raw ? ':raw' : ''}`,
       false,
-      this.normalizedStatsBuilder<IStatistics>(null, col, getNumberOfBins(this.data.length), raw)
+      this.statsBuilder<IStatistics>(null, col, getNumberOfBins(this.data.length), raw)
     );
   }
 

--- a/src/provider/tasks.ts
+++ b/src/provider/tasks.ts
@@ -12,7 +12,7 @@ import {
   ICategoricalStatistics,
   IDateStatistics,
   IStatistics,
-  normalizedStatsBuilder,
+  numberStatsBuilder,
   dateValueCache2Value,
   categoricalValueCache2Value,
   joinIndexArrays,
@@ -36,6 +36,7 @@ import {
   Ranking,
   UIntTypedArray,
   ICategory,
+  isMapAbleColumn,
 } from '../model';
 import { IRenderTask, IRenderTasks } from '../renderer';
 import { CompareLookup } from './sort';
@@ -237,14 +238,19 @@ export class ARenderTasks {
     return this.numberStatsBuilder(b, order, col, raw, build);
   }
 
-  protected normalizedStatsBuilder<R = IStatistics>(
+  protected resolveDomain(col: INumberColumn, raw: boolean): [number, number] {
+    const domain = raw && isMapAbleColumn(col) ? col.getMapping().domain : [0, 1];
+    return [domain[0], domain[domain.length - 1]];
+  }
+
+  protected statsBuilder<R = IStatistics>(
     order: IndicesArray | null | MultiIndices,
     col: INumberColumn,
     numberOfBins: number,
     raw?: boolean,
     build?: (stat: IStatistics) => R
   ) {
-    const b = normalizedStatsBuilder(numberOfBins);
+    const b = numberStatsBuilder(this.resolveDomain(col, raw ?? false), numberOfBins);
     return this.numberStatsBuilder(b, order, col, raw, build);
   }
 

--- a/src/renderer/HistogramCellRenderer.ts
+++ b/src/renderer/HistogramCellRenderer.ts
@@ -1,4 +1,4 @@
-import { normalizedStatsBuilder, IStatistics, getNumberOfBins } from '../internal';
+import { numberStatsBuilder, IStatistics, getNumberOfBins } from '../internal';
 import {
   Column,
   IDataRow,
@@ -54,7 +54,7 @@ export default class HistogramCellRenderer implements ICellRendererFactory {
         if (renderMissingDOM(n, col, row)) {
           return;
         }
-        const b = normalizedStatsBuilder(guessedBins);
+        const b = numberStatsBuilder([0, 1], guessedBins);
         for (const n of col.getNumbers(row)) {
           b.push(n);
         }

--- a/src/renderer/HistogramCellRenderer.ts
+++ b/src/renderer/HistogramCellRenderer.ts
@@ -149,7 +149,7 @@ function interactiveSummary(
       if (!updateFilter) {
         updateFilter = initFilter(node, fContext);
       }
-      return context.tasks.summaryNumberStats(col).then((r) => {
+      return context.tasks.summaryNumberStats(col, true /* raw */).then((r) => {
         if (typeof r === 'symbol') {
           return;
         }
@@ -197,7 +197,7 @@ export function createNumberFilter(
   const updateFilter = initFilter(summaryNode, fContext);
 
   const rerender = () => {
-    const ready = context.tasks.summaryNumberStats(col).then((r) => {
+    const ready = context.tasks.summaryNumberStats(col, true /* raw */).then((r) => {
       if (typeof r === 'symbol') {
         return;
       }


### PR DESCRIPTION
Closes: #397

**Prerequisites**:

* [x] Branch is up-to-date with the branch to be merged with, i.e. develop
* [x] Build is successful
* [x] Code is cleaned up and formatted 

### Summary
 
shows the raw histogram in the interactive side panel:

![image](https://user-images.githubusercontent.com/4129778/109487927-2bdbdb80-7a85-11eb-8f62-0930caa54180.png)

Thus in the inverted case the visible filter slide matches again the shown histogram. The summary in the column still shows the normalized histogram, since it should match the visible bars. 