### PR TITLE
build: set importHelpers to false for tslib compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "ESNext",
     "target": "ES5",
-    "importHelpers": true,
+    "importHelpers": false,
     "sourceMap": true,
     "lib": ["DOM", "ES2015", "es2016.array.include", "es2017.object"],
     "composite": true,


### PR DESCRIPTION
Closes #423 

**Prerequisites**:

* [x] Branch is up-to-date with the branch to be merged with, i.e. develop
* [x] Build is successful
* [x] Code is cleaned up and formatted 
* [ ] Tested with Firefox ESR, latest Firefox, latest Chrome, Edge 18


### Summary
 Quick fix for tslib compatibility issue: https://github.com/lineupjs/lineupjs/issues/423
Please discuss this approach in the ticket, as setting `importHelpers: false` **IS NOT IDEAL AS IT DEFEATS ITS PURPOSE**, but still better than introducing a breaking change in a minor version. 
Any better solution is appreciated, but we would need a *quick* solution. 