### PR TITLE
Switch module to ES2015 in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "ESNext",
+    "module": "ES2015",
     "target": "ES5",
     "importHelpers": true,
     "sourceMap": true,


### PR DESCRIPTION
Fixes #425

**Prerequisites**:

* [x] Branch is up-to-date with the branch to be merged with, i.e. develop
* [x] Build is successful
* [x] Code is cleaned up and formatted 
* [ ] Tested with Firefox ESR, latest Firefox, latest Chrome, Edge 18


### Summary
 
Switch `module` setting in tsconfig.json from `esnext` to `es2015`. 

The `esnext` flag is using `ES2020` and [the mentioned syntax](https://github.com/lineupjs/lineupjs/issues/425) since TypeScript 3.8 (see https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#es2020-for-target-and-module). With the dependency update lineupjs switched from Typescript 3.5 to 4.2. Hence, we must explicitly pin `es2015` for now.