### PR TITLE
fix exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,20 @@
   "global": "LineUpJS",
   "main": "build/LineUpJS.js",
   "unpkg": "build/LineUpJS.js",
+  "jsdelivr": "build/LineUpJS.js",
   "module": "build/src/index.js",
   "types": "build/src/index.d.ts",
-  "exports": "./build/src/index.js",
+  "exports": {
+    ".": {
+      "import": "./build/src/index.js",
+      "require": "./build/LineUpJS.js",
+      "style": "./build/LineUpJS.css",
+      "sass": "./src/style.scss",
+      "types": "./build/src/index.d.ts"
+    },
+    "./src/*": "./build/src/*.js",
+    "./build/*": "./dist/*"
+  },
   "styles": "build/LineUpJS.css",
   "sideEffects": [
     "*.scss",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,9 @@
       "sass": "./src/style.scss",
       "types": "./build/src/index.d.ts"
     },
-    "./src/*": "./build/src/*.js",
-    "./build/*": "./dist/*"
+    "./*": "./build/src/*.js",
+    "./build/*": "./build/*",
+    "./src/*": "./src/*"
   },
   "styles": "build/LineUpJS.css",
   "sideEffects": [


### PR DESCRIPTION
**prerequisites**:

- [x] branch is up-to-date with the branch to be merged with, i.e. develop
- [x] build is successful
- [x] code is cleaned up and formatted

## Summary

the [exports fields](https://webpack.js.org/guides/package-exports/) is quite new and its syntax isn't that stable yet. Moreover, with more tools consider this field, things will fail if the exports field won't include that