### PR TITLE
Missing value for StackColumn if at least one child value is missing

### DIFF
--- a/src/model/StackColumn.ts
+++ b/src/model/StackColumn.ts
@@ -325,6 +325,10 @@ export default class StackColumn extends CompositeNumberColumn implements IMulti
 
   protected compute(row: IDataRow) {
     const w = this.getWidth();
+    // missing value for the stack column if at least one child value is missing
+    if (this._children.some((d) => d.getValue(row) === null)) {
+      return null;
+    }
     return this._children.reduce((acc, d) => acc + d.getValue(row) * (d.getWidth() / w), 0);
   }
 


### PR DESCRIPTION
Fixes #453

**prerequisites**:

- [x] branch is up-to-date with the branch to be merged with, i.e. develop
- [x] build is successful
- [x] code is cleaned up and formatted

## Summary

Display missing value for the StackColumn if at least one child value is missing.

**Before**

![grafik](https://user-images.githubusercontent.com/5851088/125062723-00aa6e00-e0af-11eb-9268-5d717718d4f9.png)

**After**

![grafik](https://user-images.githubusercontent.com/5851088/126006204-3619c4af-c005-47c3-bb91-c89ad5fd88d4.png)

The corresponding log output

![grafik](https://user-images.githubusercontent.com/5851088/126006290-467af53b-4ebe-4916-b075-dcc9aef801e2.png)
