### PR TITLE
Support null variant in builder and convert null to NaN

### DIFF
--- a/demo/manual.html
+++ b/demo/manual.html
@@ -36,6 +36,12 @@
             domain: [0, Number.NaN],
           },
           {
+            type: 'number',
+            label: 'a_null',
+            column: 'a',
+            domain: [0, null],
+          },
+          {
             type: 'categorical',
             column: 'cat',
             categoryOrder: 'small-to-large',

--- a/src/builder/column/NumberColumnBuilder.ts
+++ b/src/builder/column/NumberColumnBuilder.ts
@@ -11,10 +11,14 @@ export default class NumberColumnBuilder extends ColumnBuilder<INumberColumnDesc
   /**
    * defines the mapping for this number column to normalize the data
    * @param {"linear" | "sqrt" | "pow1.1" | "pow2" | "pow3"} type mapping type
-   * @param {[number , number]} domain input data domain [min, max]
+   * @param {[number | null, number | null]} domain input data domain [min, max]
    * @param {[number , number]} range optional output domain [0, 1]
    */
-  mapping(type: 'linear' | 'sqrt' | 'pow1.1' | 'pow2' | 'pow3', domain: [number, number], range?: [number, number]) {
+  mapping(
+    type: 'linear' | 'sqrt' | 'pow1.1' | 'pow2' | 'pow3',
+    domain: [number | null, number | null],
+    range?: [number, number]
+  ) {
     if (type === 'linear') {
       this.desc.domain = domain;
       if (range) {
@@ -135,12 +139,12 @@ export default class NumberColumnBuilder extends ColumnBuilder<INumberColumnDesc
       this.mapping('linear', this.derive(data));
     } else {
       const d = this.desc.domain || this.desc.map!.domain;
-      if (Number.isNaN(d[0]) || Number.isNaN(d[1])) {
+      if (Number.isNaN(d[0]) || d[0] == null || Number.isNaN(d[1]) || d[1] == null) {
         const ext = this.derive(data);
-        if (Number.isNaN(d[0])) {
+        if (Number.isNaN(d[0]) || d[0] == null) {
           d[0] = ext[0];
         }
-        if (Number.isNaN(d[1])) {
+        if (Number.isNaN(d[1]) || d[1] == null) {
           d[1] = ext[1];
         }
       }
@@ -152,10 +156,10 @@ export default class NumberColumnBuilder extends ColumnBuilder<INumberColumnDesc
 /**
  * builds numerical column builder
  * @param {string} column column which contains the associated data
- * @param {[number , number]} domain domain (min, max) of this column
+ * @param {[number | null, number | null]} domain domain (min, max) of this column
  * @returns {NumberColumnBuilder}
  */
-export function buildNumberColumn(column: string, domain?: [number, number]) {
+export function buildNumberColumn(column: string, domain?: [number | null, number | null]) {
   const r = new NumberColumnBuilder(column);
   if (domain) {
     r.mapping('linear', domain);

--- a/src/model/MappingFunction.ts
+++ b/src/model/MappingFunction.ts
@@ -48,6 +48,13 @@ function fixDomain(domain: number[], type: string) {
   if (type === 'log' && domain[0] === 0) {
     domain[0] = 0.0000001; //0 is bad
   }
+  // replace Null with NaN since D3 converts them to 0
+  if (domain[0] == null) {
+    domain[0] = Number.NaN;
+  }
+  if (domain[1] == null) {
+    domain[1] = Number.NaN;
+  }
   return domain;
 }
 
@@ -70,7 +77,7 @@ export class ScaleMappingFunction implements IMappingFunction {
     } else {
       const dump = domain;
       this.type = dump.type;
-      this.s = toScale(dump.type).domain(dump.domain).range(dump.range);
+      this.s = toScale(dump.type).domain(fixDomain(dump.domain, dump.type)).range(dump.range);
     }
   }
 
@@ -236,7 +243,7 @@ export function restoreMapping(desc: IMapAbleDesc, factory: ITypeFactory): IMapp
   if (desc.map) {
     return factory.mappingFunction(desc.map);
   }
-  return new ScaleMappingFunction(desc.domain || [0, 1], 'linear', desc.range || [0, 1]);
+  return new ScaleMappingFunction(fixDomain(desc.domain || [0, 1], 'linear'), 'linear', desc.range || [0, 1]);
 }
 
 export function mappingFunctions() {

--- a/src/model/NumberColumn.ts
+++ b/src/model/NumberColumn.ts
@@ -25,7 +25,7 @@ import {
   IColorMappingFunction,
   IMapAbleColumn,
 } from './INumberColumn';
-import { restoreMapping, ScaleMappingFunction } from './MappingFunction';
+import { restoreMapping } from './MappingFunction';
 import { isMissingValue, isUnknown, missingGroup } from './missing';
 import type { dataLoaded } from './ValueColumn';
 import ValueColumn from './ValueColumn';
@@ -191,10 +191,8 @@ export default class NumberColumn extends ValueColumn<number> implements INumber
 
   restore(dump: any, factory: ITypeFactory) {
     super.restore(dump, factory);
-    if (dump.map) {
-      this.mapping = factory.mappingFunction(dump.map);
-    } else if (dump.domain) {
-      this.mapping = new ScaleMappingFunction(dump.domain, 'linear', dump.range || [0, 1]);
+    if (dump.map || dump.domain) {
+      this.mapping = restoreMapping(dump, factory);
     }
     if (dump.colorMapping) {
       this.colorMapping = factory.colorMappingFunction(dump.colorMapping);


### PR DESCRIPTION
closes #544

**prerequisites**:

- [x] branch is up-to-date with the branch to be merged with, i.e. develop
- [x] build is successful
- [x] code is cleaned up and formatted

## Summary

the builder wasn't support the null variant in detecting whether it should derive some mapping data. Note: the builder derives the mapping based on the data given to the builder. It doesn't propagate the missing mapping domain to the column itself. Since the builder has all the data, this wasn't a use case.

+ added that nulls will be converted to NaN before giving it to d3. This will avoid that the values will be converted to 0.