### PR TITLE
Readd deleted resize-helper

### DIFF
--- a/src/ui/EngineRenderer.ts
+++ b/src/ui/EngineRenderer.ts
@@ -132,6 +132,13 @@ export default class EngineRenderer extends AEventDispatcher {
 
     {
       // helper object for better resizing experience
+      const footer = this.table.node.querySelector(`.${engineCssClass('body')} .${engineCssClass('footer')}`)!;
+      const copy = footer.cloneNode(true) as HTMLElement;
+      copy.classList.add(cssClass('resize-helper'));
+      footer!.insertAdjacentElement('afterend', copy);
+    }
+    {
+      // selection indicator
       const body = this.table.node.querySelector<HTMLElement>(`.${engineCssClass('body')}`)!;
       this.selectionIndicator = new SelectionIndicator(body);
       parent.insertBefore(this.selectionIndicator.node, this.node);


### PR DESCRIPTION
closes #545

**prerequisites**:

- [x] branch is up-to-date with the branch to be merged with, i.e. develop
- [x] build is successful
- [x] code is cleaned up and formatted

## Summary

re add the missing resize-helper that seems to be deleted by accident when adding the selection indicator