### PR TITLE
Fix switch visualizations outside of the viewport

### DIFF
--- a/src/ui/EngineRanking.ts
+++ b/src/ui/EngineRanking.ts
@@ -949,12 +949,14 @@ export default class EngineRanking extends ACellTableSection<RenderColumn> imple
     for (let i = this.visibleColumns.first; i < index; ++i) {
       x += columns[i].width + COLUMN_PADDING;
     }
+    // may not match if not all left columns are shown
+    const nodeIndex = index - this.visibleColumns.first;
     super.forEachRow((row, rowIndex) => {
       if (EngineRanking.isCanvasRenderedRow(row)) {
         this.updateCanvasCell(row.firstElementChild! as HTMLCanvasElement, row, rowIndex, column, x);
         return;
       }
-      this.updateCellImpl(column, row.children[index] as HTMLElement, rowIndex);
+      this.updateCellImpl(column, row.children[nodeIndex] as HTMLElement, rowIndex);
     });
     return true;
   }


### PR DESCRIPTION
Closes #560

**prerequisites**:

- [x] branch is up-to-date with the branch to be merged with, i.e. develop
- [x] build is successful
- [x] code is cleaned up and formatted

## Summary

* Visualizations are now correctly updated for columns outside of the current viewport

![lineup-offscreen-column](https://user-images.githubusercontent.com/5851088/165736641-e46caf5e-dd5e-4f4b-8dc1-8ddf105d103a.gif)
