### PR TITLE
Set `font-family` to Font Awesome 6 when using external FA

### DIFF
--- a/src/styles/icons/_index.scss
+++ b/src/styles/icons/_index.scss
@@ -76,7 +76,7 @@ $lu_icon_window_restore: '\f2d2';
   @if $lu_use_font_awesome == true {
     @include fa-icon();
 
-    font-family: 'Font Awesome 5 Free', serif;
+    font-family: 'Font Awesome 6 Free', serif;
     font-weight: 900;
   } @else {
     display: inline-block;

--- a/src/styles/icons/_index.scss
+++ b/src/styles/icons/_index.scss
@@ -76,8 +76,8 @@ $lu_icon_window_restore: '\f2d2';
   @if $lu_use_font_awesome == true {
     @include fa-icon();
 
-    font-family: 'Font Awesome 6 Free', serif;
-    font-weight: 900;
+    font-family: $fa-style-family, serif;
+    font-weight: $fa-style;
   } @else {
     display: inline-block;
     font: normal normal normal 14px/1 lu-font, serif; // shortening font declaration


### PR DESCRIPTION
**prerequisites**:

- [x] branch is up-to-date with the branch to be merged with, i.e. develop
- [x] build is successful
- [x] code is cleaned up and formatted

## Summary

The Font Awesome dependency has been updated from version 5 to version 6 with commit c0d29ff91cb2f147e50ac068617c816a5cbef3e7. However, the font-family has not been updated which results in broken icons. Using the the correct font family name fixes the icons.

Please note that the custom lu-font is still using/set to `Font Awesome 5`.