### PR TITLE
feat: allow for custom HTML label generation

### DIFF
--- a/demo/htmlLabel.html
+++ b/demo/htmlLabel.html
@@ -24,7 +24,10 @@
         const builder = LineUpJS.builder(arr);
 
         // manually define columns
-        builder.deriveColumns().column(LineUpJS.buildStringColumn('d').htmlLabel('<strong>STRONG</strong>'));
+        builder
+          .deriveColumns()
+          .column(LineUpJS.buildStringColumn('d').htmlLabel('<strong>STRONG</strong>'))
+          .column(LineUpJS.buildStringColumn('d').htmlLabel('DD', (col, ctx) => `<i>${col.label}</i>`));
 
         builder.defaultRanking();
 

--- a/src/builder/column/ColumnBuilder.ts
+++ b/src/builder/column/ColumnBuilder.ts
@@ -1,4 +1,4 @@
-import type { IArrayDesc, IColumnDesc } from '../../model';
+import type { IArrayDesc, IColumnDesc, IStyleHTMLWrapper } from '../../model';
 
 export default class ColumnBuilder<T extends IColumnDesc = IColumnDesc> {
   protected readonly desc: T;
@@ -14,9 +14,9 @@ export default class ColumnBuilder<T extends IColumnDesc = IColumnDesc> {
     this.desc.label = label;
     return this;
   }
-  htmlLabel(label: string) {
+  htmlLabel(label: string, render?: IStyleHTMLWrapper) {
     this.desc.label = label;
-    this.desc.labelAsHTML = true;
+    this.desc.labelAsHTML = render ?? true;
     return this;
   }
 
@@ -35,9 +35,9 @@ export default class ColumnBuilder<T extends IColumnDesc = IColumnDesc> {
     this.desc.summary = summary;
     return this;
   }
-  htmlSummary(label: string) {
+  htmlSummary(label: string, render?: IStyleHTMLWrapper) {
     this.desc.summary = label;
-    this.desc.summaryAsHTML = true;
+    this.desc.summaryAsHTML = render ?? true;
     return this;
   }
 

--- a/src/model/Column.ts
+++ b/src/model/Column.ts
@@ -703,4 +703,48 @@ export default class Column extends AEventDispatcher {
         ]);
     }
   }
+
+  getHeaderLabel(ctx: 'header' | 'sidePanel' | 'reorder'): { content: string; asHTML: boolean } {
+    if (this.desc.labelAsHTML === true) {
+      return {
+        content: this.label,
+        asHTML: true,
+      };
+    }
+    if (typeof this.desc.labelAsHTML === 'function') {
+      return {
+        content: this.desc.labelAsHTML(this, ctx),
+        asHTML: true,
+      };
+    }
+    return {
+      content: this.label,
+      asHTML: false,
+    };
+  }
+  getSummaryLabel(
+    ctx: 'header' | 'sidePanel' | 'reorder',
+    fallback: boolean = false
+  ): { content: string; asHTML: boolean } {
+    let summary = this.desc.summary;
+    if (!summary && fallback) {
+      summary = this.description;
+    }
+    if (this.desc.summaryAsHTML === true) {
+      return {
+        content: summary,
+        asHTML: true,
+      };
+    }
+    if (typeof this.desc.summaryAsHTML === 'function') {
+      return {
+        content: this.desc.summaryAsHTML(this, ctx),
+        asHTML: true,
+      };
+    }
+    return {
+      content: summary,
+      asHTML: false,
+    };
+  }
 }

--- a/src/model/interfaces.ts
+++ b/src/model/interfaces.ts
@@ -9,6 +9,11 @@ export interface IColumnConstructor {
   new (id: string, desc: Readonly<IColumnDesc> & any, factory: ITypeFactory): Column;
 }
 
+export interface IStyleHTMLWrapper {
+  (col: Column, ctx: 'header' | 'sidePanel' | 'reorder'): string;
+  (col: IColumnDesc, ctx: 'chooser'): string;
+}
+
 export interface IStyleColumn {
   /**
    * column description
@@ -21,9 +26,10 @@ export interface IStyleColumn {
   summary: string;
   /**
    * whether to render the description as HTML (unsafe)
+   * or a custom function to convert a column to its summary label in HTML
    * @default false
    */
-  summaryAsHTML?: boolean;
+  summaryAsHTML?: boolean | IStyleHTMLWrapper;
 
   /**
    * color of this column
@@ -79,9 +85,10 @@ export interface IColumnDesc extends Partial<IStyleColumn> {
 
   /**
    * whether to render the label as HTML (unsafe)
+   * or a custom function to convert a column to its summary label in HTML
    * @default false
    */
-  labelAsHTML?: boolean;
+  labelAsHTML?: boolean | IStyleHTMLWrapper;
 
   /**
    * the column type

--- a/src/ui/dialogs/MappingDialog.ts
+++ b/src/ui/dialogs/MappingDialog.ts
@@ -94,7 +94,11 @@ export default class MappingDialog extends ADialog {
           others.length > 0
             ? `<optgroup label="Copy From">${others
                 .map(
-                  (d) => `<option value="copy_${d.id}">${this.dialog.sanitize(d.label, d.desc.labelAsHTML)}</option>`
+                  (d) =>
+                    `<option value="copy_${d.id}">${this.dialog.sanitize(
+                      d.label,
+                      d.desc.labelAsHTML === true
+                    )}</option>`
                 )
                 .join('')}</optgroup>`
             : ''

--- a/src/ui/header.ts
+++ b/src/ui/header.ts
@@ -67,7 +67,6 @@ export function createHeader(col: Column, ctx: IRankingHeaderContext, options: P
   const extra = options.extraPrefix
     ? (name: string) => `${cssClass(name)} ${cssClass(`${options.extraPrefix}-${name}`)}`
     : cssClass;
-  const summary = col.getMetaData().summary;
   node.innerHTML = `
     <div class="${extra('label')} ${cssClass('typed-icon')}"></div>
     <div class="${extra('sublabel')}"></div>
@@ -81,17 +80,15 @@ export function createHeader(col: Column, ctx: IRankingHeaderContext, options: P
         : ''
     }
   `;
-  setTextOrEmpty(
-    node.firstElementChild as HTMLElement,
-    col.getWidth() < MIN_LABEL_WIDTH,
-    col.label,
-    col.desc.labelAsHTML
-  );
+
+  const label = col.getHeaderLabel('header');
+  setTextOrEmpty(node.firstElementChild as HTMLElement, col.getWidth() < MIN_LABEL_WIDTH, label.content, label.asHTML);
+  const summary = col.getSummaryLabel('header');
   setTextOrEmpty(
     node.children[1] as HTMLElement,
     col.getWidth() < MIN_LABEL_WIDTH || !summary,
-    summary,
-    col.desc.summaryAsHTML
+    summary.content,
+    summary.asHTML
   );
 
   // addTooltip(node, col);
@@ -134,13 +131,25 @@ export function createHeader(col: Column, ctx: IRankingHeaderContext, options: P
 }
 
 /** @internal */
-export function updateHeader(node: HTMLElement, col: Column, minWidth = MIN_LABEL_WIDTH) {
+export function updateHeader(
+  node: HTMLElement,
+  col: Column,
+  labelCtx: 'header' | 'sidePanel' | 'reorder' = 'header',
+  minWidth = MIN_LABEL_WIDTH
+) {
   const label = node.getElementsByClassName(cssClass('label'))[0]! as HTMLElement;
-  setTextOrEmpty(label, col.getWidth() < minWidth, col.label, col.desc.labelAsHTML);
-  const summary = col.getMetaData().summary;
+  const labelText = col.getHeaderLabel(labelCtx);
+  setTextOrEmpty(label, col.getWidth() < minWidth, labelText.content, labelText.asHTML);
+  const summaryText = col.getSummaryLabel(labelCtx);
+  const summary = col.desc.summary;
   const subLabel = node.getElementsByClassName(cssClass('sublabel'))[0] as HTMLElement;
   if (subLabel) {
-    setTextOrEmpty(subLabel, col.getWidth() < minWidth || !summary, summary, col.desc.summaryAsHTML);
+    setTextOrEmpty(
+      subLabel,
+      col.getWidth() < minWidth || !summaryText.content,
+      summaryText.content,
+      summaryText.asHTML
+    );
   }
 
   let title = col.label;

--- a/src/ui/panel/Hierarchy.ts
+++ b/src/ui/panel/Hierarchy.ts
@@ -41,27 +41,28 @@ export default class Hierarchy {
         node.dataset.typeCat = categoryOf(item.col).name;
         node.dataset.type = item.col.desc.type;
 
-        const summary = item.col.getMetaData().summary || item.col.description;
+        const header = item.col.getHeaderLabel('reorder');
+        const summary = item.col.getSummaryLabel('reorder', true);
         node.classList.toggle(cssClass('searchbox-summary-entry'), Boolean(summary));
         if (summary) {
           const label = node.ownerDocument.createElement('span');
-          if (item.col.desc.labelAsHTML) {
-            label.innerHTML = item.text;
+          if (header.asHTML) {
+            label.innerHTML = header.content;
           } else {
-            label.textContent = item.text;
+            label.textContent = header.content;
           }
           node.appendChild(label);
           const desc = node.ownerDocument.createElement('span');
-          if (item.col.desc.summaryAsHTML) {
-            label.innerHTML = summary;
+          if (summary.asHTML) {
+            label.innerHTML = summary.content;
           } else {
-            label.textContent = summary;
+            label.textContent = summary.content;
           }
           node.appendChild(desc);
-        } else if (item.col.desc.labelAsHTML) {
-          node.innerHTML = item.text;
+        } else if (header.asHTML) {
+          node.innerHTML = header.content;
         } else {
-          node.textContent = item.text;
+          node.textContent = header.content;
         }
       },
     };
@@ -105,7 +106,7 @@ export default class Hierarchy {
       const item = cache.get(col.id);
       if (item) {
         node.appendChild(item);
-        updateHeader(item, col, 0);
+        updateHeader(item, col, 'reorder', 0);
         return;
       }
       const addons = getToolbarDialogAddons(col, addonKey, this.ctx);
@@ -150,7 +151,7 @@ export default class Hierarchy {
 
       extras(d, last);
 
-      updateHeader(last, col, 0);
+      updateHeader(last, col, 'reorder', 0);
     });
   }
 

--- a/src/ui/panel/SidePanel.ts
+++ b/src/ui/panel/SidePanel.ts
@@ -75,15 +75,19 @@ export default class SidePanel {
           node.classList.toggle(cssClass('searchbox-summary-entry'), Boolean(summary));
           if (summary) {
             const label = node.ownerDocument.createElement('span');
-            if (w.desc.labelAsHTML) {
+            if (w.desc.labelAsHTML === true) {
               label.innerHTML = w.desc.label;
+            } else if (typeof w.desc.labelAsHTML === 'function') {
+              label.innerHTML = w.desc.labelAsHTML(w.desc, 'chooser');
             } else {
               label.textContent = w.desc.label;
             }
             node.appendChild(label);
             const desc = node.ownerDocument.createElement('span');
-            if (w.desc.summaryAsHTML) {
+            if (w.desc.summaryAsHTML === true) {
               desc.innerHTML = summary;
+            } else if (typeof w.desc.summaryAsHTML === 'function') {
+              desc.innerHTML = w.desc.summaryAsHTML(w.desc, 'chooser');
             } else {
               desc.textContent = summary;
             }
@@ -93,7 +97,11 @@ export default class SidePanel {
         }
       }
       if (isWrapper(item) && item.desc.labelAsHTML) {
-        node.innerHTML = item.text;
+        if (typeof item.desc.labelAsHTML === 'function') {
+          node.innerHTML = item.desc.labelAsHTML(item.desc, 'chooser');
+        } else {
+          node.innerHTML = item.text;
+        }
       } else {
         setText(node, item.text);
       }

--- a/src/ui/panel/SidePanelEntryVis.ts
+++ b/src/ui/panel/SidePanelEntryVis.ts
@@ -52,7 +52,7 @@ export default class SidePanelEntryVis {
 
   update(ctx: IRankingHeaderContext = this.ctx) {
     this.ctx = ctx;
-    updateHeader(this.node, this.column);
+    updateHeader(this.node, this.column, 'sidePanel');
     this.updateSummary();
   }
 


### PR DESCRIPTION
closes #608

**prerequisites**:

- [x] branch is up-to-date with the branch to be merged with, i.e. develop
- [x] build is successful
- [x] code is cleaned up and formatted

## Summary

alternative variant from what we have discussed:

the `labelAsHTML` allows either a boolean or a function that is rendering HTML for a given col (desc) in a given context. 