### PR TITLE
fix: remove tooltip for missing values of BoxPlotColumn

### DIFF
--- a/src/renderer/BoxplotCellRenderer.ts
+++ b/src/renderer/BoxplotCellRenderer.ts
@@ -70,6 +70,7 @@ export default class BoxplotCellRenderer implements ICellRendererFactory {
         const data = col.getBoxPlotData(d);
         n.classList.toggle(cssClass('missing'), !data);
         if (!data) {
+          n.title = '';
           return;
         }
         const label = col.getRawBoxPlotData(d)!;


### PR DESCRIPTION
Fixes #625

**prerequisites**:

- [x] branch is up-to-date with the branch to be merged with, i.e. develop
- [x] build is successful
- [x] code is cleaned up and formatted

## Summary

[lineup-fix-boxplot-missing-value.webm](https://github.com/lineupjs/lineupjs/assets/5851088/219c76b0-e5b3-4cf9-abdc-f533ec907218)



