### PR TITLE
Revert "fix: remove tooltip for missing values of BoxPlotColumn"

### DIFF
--- a/src/renderer/BoxplotCellRenderer.ts
+++ b/src/renderer/BoxplotCellRenderer.ts
@@ -70,7 +70,6 @@ export default class BoxplotCellRenderer implements ICellRendererFactory {
         const data = col.getBoxPlotData(d);
         n.classList.toggle(cssClass('missing'), !data);
         if (!data) {
-          n.title = '';
           return;
         }
         const label = col.getRawBoxPlotData(d)!;


### PR DESCRIPTION
Reverts lineupjs/lineupjs#626. Because it was accidentally merged into the main branch.