### PR TITLE
fix: remove tooltip for missing values of BoxPlotColumn

### DIFF
--- a/src/renderer/BoxplotCellRenderer.ts
+++ b/src/renderer/BoxplotCellRenderer.ts
@@ -70,6 +70,7 @@ export default class BoxplotCellRenderer implements ICellRendererFactory {
         const data = col.getBoxPlotData(d);
         n.classList.toggle(cssClass('missing'), !data);
         if (!data) {
+          n.title = '';
           return;
         }
         const label = col.getRawBoxPlotData(d)!;


### PR DESCRIPTION
Fixes #625 

See PR https://github.com/lineupjs/lineupjs/pull/626 for description that was accidentally merged into the main instead of the develop branch.