### PR TITLE
feat: deselect as default action for selection checkbox

### DIFF
--- a/src/renderer/SelectionRenderer.ts
+++ b/src/renderer/SelectionRenderer.ts
@@ -77,8 +77,8 @@ export default class SelectionRenderer implements ICellRendererFactory {
       update: (node: HTMLElement) => {
         node.onclick = (evt) => {
           evt.stopPropagation();
-          const isUnchecked = node.classList.contains(unchecked);
-          if (isUnchecked) {
+          const nothingSelected = context.provider.getSelection().length === 0;
+          if (nothingSelected) {
             context.provider.selectAllOf(col.findMyRanker()!);
             node.classList.remove(unchecked);
             node.classList.add(checked);


### PR DESCRIPTION
closes #679 

**prerequisites**:

- [x] branch is up-to-date with the branch to be merged with, i.e. develop
- [x] build is successful
- [x] code is cleaned up and formatted

## Summary

- [ ] If at least one row is selected the `(Un)Select All` checkbox in the header should de-select on the first click
- [ ] If no row is selected the `(Un)Select All` checkbox in the header should select all rows on the first click

[lineup-deselect-all-first.webm](https://github.com/user-attachments/assets/76e9b0ad-adc4-4f52-a6c7-dccb88fae2b4)


