### PR TITLE
fix: correct summary content assignment in Hierarchy class

### DIFF
--- a/src/ui/panel/Hierarchy.ts
+++ b/src/ui/panel/Hierarchy.ts
@@ -57,9 +57,9 @@ export default class Hierarchy {
           node.appendChild(label);
           const desc = node.ownerDocument.createElement('span');
           if (summary.asHTML) {
-            label.innerHTML = summary.content;
+            desc.innerHTML = summary.content;
           } else {
-            label.textContent = summary.content;
+            desc.textContent = summary.content;
           }
           node.appendChild(desc);
         } else if (header.asHTML) {


### PR DESCRIPTION
**prerequisites**:

- [x] branch is up-to-date with the branch to be merged with, i.e. develop
- [x] build is successful
- [x] code is cleaned up and formatted

## Summary

This pull request contains a minor update to the `Hierarchy` class in the `src/ui/panel/Hierarchy.ts` file. The change ensures that the `summary.content` is assigned to the `desc` element instead of the `label` element, avoiding the overriding of `header.content` in the `label` span.

An example of the issue fixed by this PR follows:

![image](https://github.com/user-attachments/assets/0862ea45-45b5-4d33-9e47-58b31e23e104)

In the photo, since `summary.content` is empty, the `header.content` gets overriden and no label is shown for the options.