### PR TITLE
fix: use column `metadata.summary` to update subline

### DIFF
--- a/src/model/Column.ts
+++ b/src/model/Column.ts
@@ -729,7 +729,7 @@ export default class Column extends AEventDispatcher {
     ctx: 'header' | 'sidePanel' | 'reorder',
     fallback: boolean = false
   ): { content: string; asHTML: boolean } {
-    let summary = this.desc.summary;
+    let summary = this.metadata.summary;
     if (!summary && fallback) {
       summary = this.description;
     }


### PR DESCRIPTION
closes https://github.com/lineupjs/lineupjs/issues/680

**prerequisites**:

- [x] branch is up-to-date with the branch to be merged with, i.e. develop
- [x] build is successful
- [x] code is cleaned up and formatted

## Summary

- Using `desc.summary` accounts only for the initial rendering but not when updating the summary from the rename dialog
- Changing the summary from the rename dialog updates the `metadata.summary`

[lineup-summary.webm](https://github.com/user-attachments/assets/7d08f686-d28c-4b03-bdee-cca3ecfec44e)
