### PR TITLE
fix: center upset line

### DIFF
--- a/src/styles/renderer/_upset.scss
+++ b/src/styles/renderer/_upset.scss
@@ -8,10 +8,10 @@
 
 .#{vars.$lu_css_prefix}-upset-line {
   position: absolute;
-  top: 0;
-  height: 50%;
-  transform: translateY(1px);
-  border-bottom: 2px solid vars.$lu_renderer_upset_color; // line
+  transform: translateY(-50%); // center
+  margin-top: 1px; // center according to line height
+  height: 2px; // line height
+  background-color: vars.$lu_renderer_upset_color; // line color
 }
 
 .#{vars.$lu_css_prefix}-upset-dot {

--- a/src/styles/renderer/_upset.scss
+++ b/src/styles/renderer/_upset.scss
@@ -8,10 +8,10 @@
 
 .#{vars.$lu_css_prefix}-upset-line {
   position: absolute;
-  transform: translateY(-50%); // center
-  margin-top: 1px; // center according to line height
-  height: 2px; // line height
-  background-color: vars.$lu_renderer_upset_color; // line color
+  top: 50%;
+  transform: translateY(-50%);
+  height: 2px;
+  background-color: vars.$lu_renderer_upset_color;
 }
 
 .#{vars.$lu_css_prefix}-upset-dot {

--- a/src/styles/renderer/_upset.scss
+++ b/src/styles/renderer/_upset.scss
@@ -10,8 +10,8 @@
   position: absolute;
   top: 0;
   height: 50%;
-  transform: translateY(-1px);
-  border-bottom: 3px solid vars.$lu_renderer_upset_color; // line
+  transform: translateY(1px);
+  border-bottom: 2px solid vars.$lu_renderer_upset_color; // line
 }
 
 .#{vars.$lu_css_prefix}-upset-dot {


### PR DESCRIPTION
closes <!--list issues here-->

**prerequisites**:

- [x] branch is up-to-date with the branch to be merged with, i.e. develop
- [x] build is successful
- [x] code is cleaned up and formatted

## Summary

* The line is 1px thinner and still centered
* Different approach to center the line


| Before | After |
|--------|--------|
| <img width="441" height="697" alt="image" src="https://github.com/user-attachments/assets/ea462f6a-fcb0-4145-94f4-e3dbc86ee97c" /> | <img width="441" height="697" alt="image" src="https://github.com/user-attachments/assets/307c6206-105f-4296-88f1-aa8e115fa482" /> |


Now, it also works in Ordino with different row height and CSS line height. Before the line was not centered.

| Before | After |
|--------|--------|
| <img width="203" height="382" alt="image" src="https://github.com/user-attachments/assets/09ce9675-d3fa-4b33-8466-0680eeaacc57" /> | <img width="203" height="382" alt="image" src="https://github.com/user-attachments/assets/8dd23f26-8c56-4e28-a1a6-e7537cc7997f" /> |


