### PR TITLE
fix: exact multi-term string column filter

### DIFF
--- a/src/internal/searchUtils.ts
+++ b/src/internal/searchUtils.ts
@@ -131,11 +131,6 @@ export function searchText(
     return true;
   }
 
-  // Handle exact match case
-  if (filterType === EStringFilterType.exact) {
-    return text.toLowerCase() === query.toLowerCase();
-  }
-
   // Multi-term search for string filters
   const searchTerms = parseSearchQuery(query);
   if (searchTerms.length > 1) {
@@ -146,6 +141,8 @@ export function searchText(
     const lowerText = text.toLowerCase();
     const lowerTerm = searchTerms[0].toLowerCase();
     switch (filterType) {
+      case EStringFilterType.exact:
+        return lowerText === lowerTerm;
       case EStringFilterType.startsWith:
         return lowerText.startsWith(lowerTerm);
       case EStringFilterType.contains:

--- a/src/model/StringColumn.ts
+++ b/src/model/StringColumn.ts
@@ -252,11 +252,6 @@ export default class StringColumn extends ValueColumn<string> {
       return r !== '' && r.match(ff) != null; // You can not use RegExp.test(), because of https://stackoverflow.com/a/6891667
     }
 
-    // Handle exact match case
-    if (filterType === EStringFilterType.exact) {
-      return r !== '' && r.toLowerCase() === ff.toLowerCase();
-    }
-
     // Multi-term search for string filters
     const searchTerms = parseSearchQuery(ff);
     if (searchTerms.length > 1) {
@@ -267,6 +262,8 @@ export default class StringColumn extends ValueColumn<string> {
       const lowerText = r.toLowerCase();
       const lowerTerm = searchTerms[0].toLowerCase();
       switch (filterType) {
+        case EStringFilterType.exact:
+          return r !== '' && lowerText === lowerTerm;
         case EStringFilterType.startsWith:
           return r !== '' && lowerText.startsWith(lowerTerm);
         case EStringFilterType.contains:

--- a/tests/model/StringColumnMultiTerm.spec.ts
+++ b/tests/model/StringColumnMultiTerm.spec.ts
@@ -147,6 +147,30 @@ describe('StringColumn Multi-term Search', () => {
       });
     });
 
+    describe('exact filter type', () => {
+      it('should match the rows with values one of the terms', () => {
+        column.setFilter({
+          filter: '"Red Apple" "orange soda"',
+          filterMissing: true,
+          filterType: EStringFilterType.exact,
+        });
+        const matches = testData.filter((row) => column.filter(row));
+        expect(matches).toHaveLength(2);
+      });
+
+      it('should not match partial terms', () => {
+        column.setFilter({ filter: 'apple', filterMissing: true, filterType: EStringFilterType.exact });
+        const matches = testData.filter((row) => column.filter(row));
+        expect(matches).toHaveLength(0);
+      });
+
+      it('should work with `,` separator', () => {
+        column.setFilter({ filter: '"apple juice","orange soda"', filterMissing: true });
+        const matches = testData.filter((row) => column.filter(row));
+        expect(matches).toHaveLength(2);
+      });
+    });
+
     describe('startsWith filter type', () => {
       it('should work with single terms', () => {
         column.setFilter({ filter: 'apple', filterMissing: true, filterType: EStringFilterType.startsWith });


### PR DESCRIPTION
closes https://github.com/datavisyn/ordino/issues/3377
**prerequisites**:

- [x] branch is up-to-date with the branch to be merged with, i.e. develop
- [x] build is successful
- [x] code is cleaned up and formatted

## Summary
The issue was that the `exactly match the search terms` behaved like an exact string match, the string was never split into terms by `comma` or `space` separators.

Since space is used as a separator strings containing spaces would have to be quoted

The solution works for both single term and multi term search
